### PR TITLE
FND-412 - Certain properties, including hasTag, remain in FIBO though they are covered in OMG Commons

### DIFF
--- a/ACTUS/ACTUSContractTermMapping.rdf
+++ b/ACTUS/ACTUSContractTermMapping.rdf
@@ -226,7 +226,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 			</owl:Restriction>
 		</rdf:type>
-		<fibo-actus-act:hasParameterMapping>Starting from the contract, (1) fibo-fnd-acc-cur:hasCurrency fibo-fnd-acc-cur:Currency; cmns-dsg:isSignifiedBy fibo-fnd-acc-cur:CurrencyIdentifier; fibo-fnd-rel-rel;hasTag xsd:string, or (2) starting specifically from a currency instrument, fibo-fnd-acc-cur:hasBaseCurrency fibo-fnd-acc-cur:Currency; cmns-dsg:isSignifiedBy fibo-fnd-acc-cur:CurrencyIdentifier; fibo-fnd-rel-rel;hasTag xsd:string, where the base currency denotes the selling currency</fibo-actus-act:hasParameterMapping>
+		<fibo-actus-act:hasParameterMapping>Starting from the contract, (1) fibo-fnd-acc-cur:hasCurrency fibo-fnd-acc-cur:Currency; cmns-dsg:isSignifiedBy fibo-fnd-acc-cur:CurrencyIdentifier; cmns-dsg;hasTag xsd:string, or (2) starting specifically from a currency instrument, fibo-fnd-acc-cur:hasBaseCurrency fibo-fnd-acc-cur:Currency; cmns-dsg:isSignifiedBy fibo-fnd-acc-cur:CurrencyIdentifier; cmns-dsg;hasTag xsd:string, where the base currency denotes the selling currency</fibo-actus-act:hasParameterMapping>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-actus-act;ACTUSContractTerm-CUR2">
@@ -236,7 +236,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 			</owl:Restriction>
 		</rdf:type>
-		<fibo-actus-act:hasParameterMapping>Starting from the contract, (1) fibo-fnd-acc-cur:hasCurrency fibo-fnd-acc-cur:Currency; cmns-dsg:isSignifiedBy fibo-fnd-acc-cur:CurrencyIdentifier; fibo-fnd-rel-rel;hasTag xsd:string, or (2) starting specifically from a currency instrument, fibo-fnd-acc-cur:hasDealtCurrency fibo-fnd-acc-cur:Currency; cmns-dsg:isSignifiedBy fibo-fnd-acc-cur:CurrencyIdentifier; fibo-fnd-rel-rel;hasTag xsd:string, where the base currency denotes the buying currency</fibo-actus-act:hasParameterMapping>
+		<fibo-actus-act:hasParameterMapping>Starting from the contract, (1) fibo-fnd-acc-cur:hasCurrency fibo-fnd-acc-cur:Currency; cmns-dsg:isSignifiedBy fibo-fnd-acc-cur:CurrencyIdentifier; cmns-dsg;hasTag xsd:string, or (2) starting specifically from a currency instrument, fibo-fnd-acc-cur:hasDealtCurrency fibo-fnd-acc-cur:Currency; cmns-dsg:isSignifiedBy fibo-fnd-acc-cur:CurrencyIdentifier; cmns-dsg;hasTag xsd:string, where the base currency denotes the buying currency</fibo-actus-act:hasParameterMapping>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-actus-act;ACTUSContractTerm-CURS">
@@ -246,7 +246,7 @@ See https://opensource.org/licenses/MIT.</dct:license>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 			</owl:Restriction>
 		</rdf:type>
-		<fibo-actus-act:hasParameterMapping>Starting from the contract, (1) fibo-fbc-fi-stl:hasPreferredSettlementCurrency fibo-fnd-acc-cur:Currency; cmns-dsg:isSignifiedBy fibo-fnd-acc-cur:CurrencyIdentifier; fibo-fnd-rel-rel;hasTag xsd:string</fibo-actus-act:hasParameterMapping>
+		<fibo-actus-act:hasParameterMapping>Starting from the contract, (1) fibo-fbc-fi-stl:hasPreferredSettlementCurrency fibo-fnd-acc-cur:Currency; cmns-dsg:isSignifiedBy fibo-fnd-acc-cur:CurrencyIdentifier; cmns-dsg;hasTag xsd:string</fibo-actus-act:hasParameterMapping>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-actus-act;ACTUSContractTerm-MOC">

--- a/BE/FunctionalEntities/FunctionalEntities.rdf
+++ b/BE/FunctionalEntities/FunctionalEntities.rdf
@@ -46,7 +46,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 		<rdfs:label>Functional Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for entities defined by their function, such as the relationship to the various forms which one or another functionally-defined entity may take. It also includes a number of basic types of entity defined by function, such as business and non-profit. The concepts in this ontology are intended to be extensible in other ontologies which may be dedicated to specific kinds of functionally-defined business entity or organization.</dct:abstract>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		<dct:license>2013-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2013-2025 Object Management Group, Inc.
 		
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -69,7 +69,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20251001/FunctionalEntities/FunctionalEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20260701/FunctionalEntities/FunctionalEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20150201/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.1 RTF report. Changes include deprecation of the SoleProprietorship class and making it equivalent to the class with the same name in the Sole Proprietorships ontology. This version also introduces a new FunctionalEntity class, as the parent of FunctionalBusinessEntity in this ontology and as the parent of Government in the GovernmentEntities ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160801/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified by the FIBO 2.0 revision to address missing labels and definitions on the deprecated sole proprietorship class to match those in the equivalent class.</skos:changeNote>
@@ -87,9 +87,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20240101/FunctionalEntities/FunctionalEntities.rdf version of this ontology was augmented to include general definitions for syndicate and syndicate member (LOAN-169).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20241101/FunctionalEntities/FunctionalEntities.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20250301/FunctionalEntities/FunctionalEntities.rdf version of the ontology was modified to loosen various constraints to better reflect use case requirements (SEC-205).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20251001/FunctionalEntities/FunctionalEntities.rdf version of the ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-be-fct-fct;Association">
@@ -177,7 +178,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/CAE/CorporateEvents/CorporateActions.rdf
+++ b/CAE/CorporateEvents/CorporateActions.rdf
@@ -12,7 +12,6 @@
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -33,7 +32,6 @@
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -44,9 +42,9 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
 		<rdfs:label xml:lang="en">Corporate Actions Ontology</rdfs:label>
 		<dct:abstract>This ontology provides a high level overview of actions including corporate, market, and regulatory actions, ranging from business oriented events such as address and name changes, to those that are more specific to securities.</dct:abstract>
-		<dct:license>Copyright (c) 2016-2025 EDM Council, Inc.
+		<dct:license>2016-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2016-2025 Object Management Group, Inc.
-
+		
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
@@ -57,7 +55,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
@@ -66,13 +63,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20250301/CorporateEvents/CorporateActions/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20260701/CorporateEvents/CorporateActions/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/CAE/20220301/CorporateEvents/CorporateActions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/CAE/20230201/CorporateEvents/CorporateActions.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/CAE/20230301/CorporateEvents/CorporateActions.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/CAE/20250301/CorporateEvents/CorporateActions.rdf version of the ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-cae-ce-act;Action">
@@ -143,14 +141,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
-				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">action classifier</rdfs:label>
@@ -162,14 +160,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStatus"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
-				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">action status</rdfs:label>

--- a/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals.rdf
@@ -7,7 +7,6 @@
 	<!ENTITY fibo-cae-ce-GLEIF "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/">
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -23,7 +22,6 @@
 	xmlns:fibo-cae-ce-GLEIF="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -34,7 +32,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/">
 		<rdfs:label xml:lang="en">GLEIF Corporate Action Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology includes the codes for corporate action events as specified in GLEIF LEI Common Data Format (CDF) schema, as of 4 March 2021.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2022-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2022-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -44,7 +51,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/GLEIF-CorporateActionIndividuals/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-GLEIF;ABSORPTION">
@@ -52,7 +60,7 @@
 		<rdfs:label xml:lang="en">ABSORPTION</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions that is a kind of merger where there is a combination of two or more companies into an existing company</skos:definition>
 		<skos:note xml:lang="en">In the case of absorption, only one company survives and all others lose their identity.</skos:note>
-		<fibo-fnd-rel-rel:hasTag>ABSORPTION</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>ABSORPTION</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -60,7 +68,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-act;MergerAcquisition"/>
 		<rdfs:label xml:lang="en">ACQUISITION_BRANCH</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions where the acquiring legal entity purchases an international branch entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ACQUISITION_BRANCH</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>ACQUISITION_BRANCH</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -68,14 +76,14 @@
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
-				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-act;Action"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">action group</rdfs:label>
@@ -88,7 +96,7 @@
 		<rdfs:label xml:lang="en">BANKRUPTCY</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions in which the status of a legal entity is that it is unable to pay creditors</skos:definition>
 		<skos:note xml:lang="en">Bankruptcy usually involves a formal court ruling. Securities may become valueless (event completed).</skos:note>
-		<fibo-fnd-rel-rel:hasTag>BANKRUPTCY</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BANKRUPTCY</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -97,7 +105,7 @@
 		<rdfs:label xml:lang="en">BREAKUP</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions in which a single company splits into two or more independent, separately-run companies</skos:definition>
 		<skos:note xml:lang="en">Regulators also can mandate break-ups of companies for anti-trust reasons.</skos:note>
-		<fibo-fnd-rel-rel:hasTag>BREAKUP</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BREAKUP</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -105,7 +113,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-act;OrganizationAddressChange"/>
 		<rdfs:label xml:lang="en">CHANGE_HQ_ADDRESS</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the headquarters address of the legal entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHANGE_HQ_ADDRESS</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>CHANGE_HQ_ADDRESS</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -113,7 +121,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-act;OrganizationAddressChange"/>
 		<rdfs:label xml:lang="en">CHANGE_LEGAL_ADDRESS</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the legal address of the legal entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHANGE_LEGAL_ADDRESS</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>CHANGE_LEGAL_ADDRESS</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -121,7 +129,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-act;LegalFormChange"/>
 		<rdfs:label xml:lang="en">CHANGE_LEGAL_FORM</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the legal form of the legal entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHANGE_LEGAL_FORM</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>CHANGE_LEGAL_FORM</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -129,7 +137,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-act;OrganizationNameChange"/>
 		<rdfs:label xml:lang="en">CHANGE_LEGAL_NAME</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the legal name of the legal entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHANGE_LEGAL_NAME</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>CHANGE_LEGAL_NAME</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -137,7 +145,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-act;OrganizationNameChange"/>
 		<rdfs:label xml:lang="en">CHANGE_OTHER_NAMES</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the trade- or doing business name of the legal entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHANGE_OTHER_NAMES</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>CHANGE_OTHER_NAMES</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -145,7 +153,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-GLEIF;ActionGroup"/>
 		<rdfs:label xml:lang="en">complex legal form group</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a more complex legal entity event including change of the legal entity status triggered by change of the legal form</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>COMPLEX_CHANGE_LEGAL_FORM</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>COMPLEX_CHANGE_LEGAL_FORM</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -154,7 +162,7 @@
 		<rdfs:label xml:lang="en">DEMERGER</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a distribution of securities issued by another legal entity</skos:definition>
 		<skos:note xml:lang="en">The distributed securities may either be of a newly created or of an existing legal entity. For example, spin-off, demerger, unbundling, divestment.</skos:note>
-		<fibo-fnd-rel-rel:hasTag>DEMERGER</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>DEMERGER</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -163,7 +171,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
 		<rdfs:label xml:lang="en">DISSOLUTION</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving (i) A voluntary termination of operations, (ii) a general assignment for the benefit of the legal entity&apos;s creditors or (iii) any other liquidation, dissolution or winding up of the legal entity (excluding a Liquidity Event), whether voluntary or involuntary (event completed)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DISSOLUTION</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>DISSOLUTION</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -179,7 +187,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
 		<rdfs:label xml:lang="en">INSOLVENCY</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving the entry of a decree or order by a court or agency or supervisory authority having jurisdiction in the premises the appointment of a trustee-in-bankruptcy or similar official for such party in any insolvency, readjustment of debt, marshalling of assets and liabilities, or similar proceedings, or for the winding up or liquidation of their respective affairs (event completed)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>INSOLVENCY</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>INSOLVENCY</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -190,7 +198,7 @@
 		<rdfs:label xml:lang="en">LIQUIDATION</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>
 		<skos:note xml:lang="en">Debt may be paid in order of priority based on preferred claims to assets specified by the security (event completed).</skos:note>
-		<fibo-fnd-rel-rel:hasTag>LIQUIDATION</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>LIQUIDATION</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -198,7 +206,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-GLEIF;ActionGroup"/>
 		<rdfs:label xml:lang="en">legal form and name group</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a change in the legal form, name, or other information such as an address change for an organization</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHANGE_LEGAL_FORM_AND_NAME</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>CHANGE_LEGAL_FORM_AND_NAME</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -207,7 +215,7 @@
 		<rdfs:label xml:lang="en">MERGERS_AND_ACQUISITIONS</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions in which a single company splits into two or more independent, separately-run companies</skos:definition>
 		<skos:note xml:lang="en">Regulators also can mandate break-ups of companies for anti-trust reasons.</skos:note>
-		<fibo-fnd-rel-rel:hasTag>MERGERS_AND_ACQUISITIONS</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>MERGERS_AND_ACQUISITIONS</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -215,7 +223,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-GLEIF;ActionGroup"/>
 		<rdfs:label xml:lang="en">reverse takeover group</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions that are part of a reverse takeover event</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>REVERSE_TAKEOVER</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>REVERSE_TAKEOVER</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -223,7 +231,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-act;SpinOff"/>
 		<rdfs:label xml:lang="en">SPINOFF</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions where the shareholders of the original entity are compensated for the value loss of the original entity via shares of the new entity or via dividend</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SPINOFF</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>SPINOFF</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -231,7 +239,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-GLEIF;ActionGroup"/>
 		<rdfs:label xml:lang="en">standalone group</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions that are single, standalone events rather than a combination of multiple events</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>STANDALONE</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>STANDALONE</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -239,7 +247,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-act;MergerAcquisition"/>
 		<rdfs:label xml:lang="en">TRANSFORMATION_BRANCH_TO_SUBSIDIARY</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving the transfer of all of the assets and liabilities of an International Branch to the new subsidiary entity in exchange for the transfer of securities representing the capital of the subsidiary entity receiving the transfer</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TRANSFORMATION_BRANCH_TO_SUBSIDIARY</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>TRANSFORMATION_BRANCH_TO_SUBSIDIARY</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -247,7 +255,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-act;MergerAcquisition"/>
 		<rdfs:label xml:lang="en">TRANSFORMATION_SUBSIDIARY_TO_BRANCH</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving the transfer of all of the assets and liabilities of a subsidiary to an International Branch entity in exchange for the transfer of securities representing the capital of the International Branch entity receiving the transfer</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TRANSFORMATION_SUBSIDIARY_TO_BRANCH</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>TRANSFORMATION_SUBSIDIARY_TO_BRANCH</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -255,7 +263,7 @@
 		<rdf:type rdf:resource="&fibo-cae-ce-act;LegalFormChange"/>
 		<rdfs:label xml:lang="en">TRANSFORMATION_UMBRELLA_TO_STANDALONE</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions involving a notification of a change in the legal form from a Fund legal entity structure with one or more than one sub-funds/compartments to a Fund legal entity structure without sub-funds/compartments</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TRANSFORMATION_UMBRELLA_TO_STANDALONE</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>TRANSFORMATION_UMBRELLA_TO_STANDALONE</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -264,7 +272,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-dae-cre;EntitySpecificCreditEvent"/>
 		<rdfs:label xml:lang="en">VOLUNTARY_ARRANGEMENT</rdfs:label>
 		<skos:definition xml:lang="en">GLEIF classifier for corporate actions consisting of a procedure that allows a legal entity to settle debts by paying only a proportion of the amount that it owes to creditors or to come to some other arrangement with its creditors over the payment of its debts (event completed)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>VOLUNTARY_ARRANGEMENT</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>VOLUNTARY_ARRANGEMENT</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-GLEIF;GLEIF-CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 

--- a/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
+++ b/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals.rdf
@@ -9,7 +9,6 @@
 	<!ENTITY fibo-cae-ce-act "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/">
 	<!ENTITY fibo-cae-ce-srca "https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/">
 	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -27,7 +26,6 @@
 	xmlns:fibo-cae-ce-act="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"
 	xmlns:fibo-cae-ce-srca="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"
 	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -38,7 +36,16 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/">
 		<rdfs:label xml:lang="en">ISO 15022 Corporate Action Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology includes the codes for income and corporate action events as specified in ISO 15022, including extensions as of 3 September 2020. Scope excludes lower-level notification and meetings related events and message definitions associated with ISO 15022 as well as related messages covered by ISO 20022.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2016-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2016-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/SecurityRelatedCorporateActions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
@@ -50,7 +57,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/ISO15022-CorporateActionIndividuals/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-		<cmns-av:copyright>Copyright (c) 2016-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-15022;BIDS">
@@ -63,8 +71,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">BIDS</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions in which an offer is made to existing shareholders by the issuing company to repurchase equity or other securities convertible into equity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BIDS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>BIDS</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -78,8 +86,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">BONU</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BONU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>BONU</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -93,8 +101,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">BPUT</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve early redemption of a security at the election of the holder subject to the terms and condition of the issue with no reduction in nominal value</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BPUT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>BPUT</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -108,8 +116,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">CAPD</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the issuer&apos;s capital account</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CAPD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>CAPD</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -123,8 +131,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">CAPG</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that distribute profits resulting from the sale of company assets to shareholders</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CAPG</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>CAPG</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -138,8 +146,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">CHAN</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that disseminate information regarding a change further described in the corporate action details</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHAN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>CHAN</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -153,8 +161,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">CLSA</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving a situation where interested parties seek restitution for financial loss</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CLSA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>CLSA</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -168,8 +176,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">CONS</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve procedures aiming to obtain consent of holder to a proposal by the issuer or a third party without convening a meeting</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CONS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>CONS</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -183,8 +191,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">CONV</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve conversion of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price/ratio</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CONV</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>CONV</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -198,8 +206,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">DECR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that reduce the face value of a share or the value of fund assets</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DECR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>DECR</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -213,8 +221,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">DFLT</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that indicate a failure by the issuer to perform obligations defined as default events under the bond agreement and that have not been remedied</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DFLT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>DFLT</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -228,8 +236,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">DRIP</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a dividend payment whereby holders can keep cash or have the cash reinvested into additional shares in the issuing company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DRIP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>DRIP</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -243,8 +251,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">DSCL</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a requirement for holders or beneficial owners to disclose their name, location and holdings of any issue to the issuer</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DSCL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>DSCL</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -258,8 +266,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">DTCH</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving parties wishing to acquire a security</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DTCH</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>DTCH</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -273,8 +281,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">DVCA</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that distribute cash to shareholders in proportion to their equity holding</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DVCA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>DVCA</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -288,8 +296,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">DVOP</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders with a choice of benefit to receive</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DVOP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>DVOP</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -303,8 +311,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">DVSE</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a dividend to shareholders in the form of equities of the issuing corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DVSE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>DVSE</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -318,8 +326,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">EXOF</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that reflect an exchange of holdings for other securities and/or cash</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>EXOF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>EXOF</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -333,8 +341,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">EXRI</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a call or exercise on nil paid securities or intermediate securities resulting from an intermediate securities distribution (RHDI)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>EXRI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>EXRI</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -348,8 +356,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">EXTM</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve prolonging the maturity date of a bond</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>EXTM</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>EXTM</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -364,8 +372,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">EXWA</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that offer holders the option to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>EXWA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>EXWA</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -379,8 +387,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">INFO</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>INFO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>INFO</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -394,8 +402,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">INTR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve distribution of a regular interest payment to holders of an interest-bearing asset</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>INTR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>INTR</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -415,8 +423,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">LIQU</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions consisting of distribution of cash, assets, or both</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>LIQU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>LIQU</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -430,8 +438,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">MCAL</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities prior to maturity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MCAL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>MCAL</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -445,8 +453,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">MRGR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve the exchange of outstanding securities, initiated by the issuer which may include options, as the result of two or more companies combining assets, that is, an external, third party company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MRGR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>MRGR</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -460,8 +468,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">PARI</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that occur when securities with different characteristics become identical in all respects</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PARI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>PARI</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -475,8 +483,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">PCAL</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with reduction of the nominal value of the securities</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PCAL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>PCAL</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -490,8 +498,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">PRED</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of securities in part before their scheduled final maturity date with no reduction in nominal value</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PRED</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>PRED</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -505,8 +513,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">PRIO</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a public offer where priority is given to existing shareholders</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PRIO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>PRIO</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -520,8 +528,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">REDM</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve redemption of an entire issue outstanding of securities at final maturity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>REDM</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>REDM</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -535,8 +543,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">REDO</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions by which the unit (currency and/or nominal) of a security is restated</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>REDO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>REDO</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -550,8 +558,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">RHDI</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving the distribution of intermediate securities or privilege that gives the holder the right to take part in a future event</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RHDI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>RHDI</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -565,8 +573,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">SHPR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that pay shareholders an amount in cash issued from the shares premium reserve</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SHPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>SHPR</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -580,8 +588,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">SOFF</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve the distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SOFF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>SOFF</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -595,8 +603,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">SPLF</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve an increase in a corporation&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SPLF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>SPLF</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -610,8 +618,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">SPLR</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve a decrease in a company&apos;s number of outstanding equities without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SPLR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>SPLR</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -625,8 +633,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">TEND</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions involving information provided by the issuer having no accounting/financial impact on the holder</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TEND</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>TEND</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 	
@@ -641,8 +649,8 @@
 		</rdf:type>
 		<rdfs:label xml:lang="en">WRTH</rdfs:label>
 		<skos:definition xml:lang="en">ISO 15022 classifier for corporate actions that involve booking out of valueless securities</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WRTH</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
+		<cmns-dsg:hasTag>WRTH</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-cae-ce-15022;ISO15022CorporateActionClassificationScheme"/>
 	</owl:NamedIndividual>
 

--- a/EXMP/LegalEntities/DowJonesIndustrialAverageCompanies.rdf
+++ b/EXMP/LegalEntities/DowJonesIndustrialAverageCompanies.rdf
@@ -127,7 +127,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>The Proctor &amp; Gamble Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Proctor &amp; Gamble Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>2572IBTT8CCZW6AU4141</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>2572IBTT8CCZW6AU4141</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;TheProctorAndGambleCompany-US-OH"/>
 	</owl:NamedIndividual>
 	
@@ -149,7 +149,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Alphabet Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Alphabet Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5493006MHB84DD0ZWV18</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5493006MHB84DD0ZWV18</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;AlphabetInc-US-CA"/>
 	</owl:NamedIndividual>
 	
@@ -172,7 +172,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Apple Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Apple Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HWUPKR0MPOU8FGXBT394</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>HWUPKR0MPOU8FGXBT394</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;AppleInc-US-CA"/>
 	</owl:NamedIndividual>
 	
@@ -194,7 +194,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>The Home Depot, Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Home Depot, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>QEKMOTMBBKA8I816DO57</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>QEKMOTMBBKA8I816DO57</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;TheHomeDepotInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -216,7 +216,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>The Coca-Cola Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Coca-Cola Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UWJKFUJFZ02DKWI3RY53</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>UWJKFUJFZ02DKWI3RY53</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;TheCoca-ColaCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -238,7 +238,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>International Business Machines Corporation legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for International Business Machines Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>VGRQXHF3J8VDLUA7XE92</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>VGRQXHF3J8VDLUA7XE92</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;InternationalBusinessMachinesCorporation-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -277,7 +277,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for Alphabet Inc.</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate>2015-07-23</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fnd-rel-rel:hasTag>5786925</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5786925</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;AlphabetInc-US-CA"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -325,7 +325,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>registration identifier assigned by the California Department of Corporations for Apple Inc.</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate>1977-01-03</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fnd-rel-rel:hasTag>806592</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>806592</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;AppleInc-US-CA"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessEntitiesRegistry"/>
@@ -383,7 +383,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>registration identifier assigned by the New York Division of Corporations for International Business Machines Corporation</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate>1924-02-14</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fnd-rel-rel:hasTag>30059</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>30059</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;InternationalBusinessMachinesCorporation-US-NY"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
@@ -394,11 +394,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>International Business Machines Corporation Business Identifier Code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for International Business Machines Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IBMXUS33XXX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-djiac;InternationalBusinessMachinesCorporationBusinessPartyPrefix"/>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-djiac;InternationalBusinessMachinesCorporationBusinessPartySuffix"/>
 		<cmns-col:comprises rdf:resource="&lcc-3166-1;US"/>
 		<cmns-cxtdsg:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-dsg:hasTag>IBMXUS33XXX</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;InternationalBusinessMachinesCorporation-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -406,16 +406,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>International Business Machines Corporation business party prefix</rdfs:label>
 		<skos:definition>business party prefix for International Business Machines Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IBMX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-djiac;InternationalBusinessMachinesCorporationBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>IBMX</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-djiac;InternationalBusinessMachinesCorporationBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>International Business Machines Corporation business party suffix</rdfs:label>
 		<skos:definition>business party suffix for International Business Machines Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>33</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-djiac;InternationalBusinessMachinesCorporationBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>33</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-djiac;InternationalBusinessMachinesCorporationIncorporationDate">
@@ -446,7 +446,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>registration identifier assigned by the Delaware Division of Corporations for The Coca-Cola Company</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate>1919-09-05</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fnd-rel-rel:hasTag>88529</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>88529</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;TheCoca-ColaCompany-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -457,11 +457,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>The Coca-Cola Company business identifier code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for The Coca-Cola Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TCCCUS33XXX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-djiac;TheCoca-ColaCompanyBusinessPartyPrefix"/>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-djiac;TheCoca-ColaCompanyBusinessPartySuffix"/>
 		<cmns-col:comprises rdf:resource="&lcc-3166-1;US"/>
 		<cmns-cxtdsg:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-dsg:hasTag>TCCCUS33XXX</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;TheCoca-ColaCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -469,16 +469,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>The Coca-Cola Company business party prefix</rdfs:label>
 		<skos:definition>business party prefix for The Coca-Cola Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TCCC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-djiac;TheCoca-ColaCompanyBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>TCCC</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-djiac;TheCoca-ColaCompanyBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>The Coca-Cola Company business party suffix</rdfs:label>
 		<skos:definition>business party suffix for The Coca-Cola Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>33</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-djiac;TheCoca-ColaCompanyBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>33</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-djiac;TheCoca-ColaCompanyCorporateAddress">
@@ -505,7 +505,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>registration identifier assigned by the Delaware Division of Corporations for The Home Depot, Inc.</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate>1978-06-29</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fnd-rel-rel:hasTag>856429</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>856429</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;TheHomeDepotInc-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -564,7 +564,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>registration identifier assigned by the Ohio Department of Corporations for The Proctor &amp; Gamble Company</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate>1905-05-05</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fnd-rel-rel:hasTag>20677</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>20677</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;TheProctorAndGambleCompany-US-OH"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal"/>
@@ -575,11 +575,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>The Proctor &amp; Gamble Company business identifier code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for The Proctor &amp; Gamble Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PGGTUS33XXX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-djiac;TheProctorAndGambleCompanyBusinessPartyPrefix"/>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-djiac;TheProctorAndGambleCompanyBusinessPartySuffix"/>
 		<cmns-col:comprises rdf:resource="&lcc-3166-1;US"/>
 		<cmns-cxtdsg:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-dsg:hasTag>PGGTUS33XXX</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-djiac;TheProctorAndGambleCompany-US-OH"/>
 	</owl:NamedIndividual>
 	
@@ -587,16 +587,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>The Proctor &amp; Gamble Company business party prefix</rdfs:label>
 		<skos:definition>business party prefix for The Proctor &amp; Gamble Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PGGT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-djiac;TheProctorAndGambleCompanyBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>PGGT</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-djiac;TheProctorAndGambleCompanyBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>The Proctor &amp; Gamble Company business party suffix</rdfs:label>
 		<skos:definition>business party suffix for The Proctor &amp; Gamble Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>33</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-djiac;TheProctorAndGambleCompanyBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>33</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-djiac;TheProctorAndGambleCompanyCorporateAddress">

--- a/EXMP/LegalEntities/FinancialInstitutionExamples.rdf
+++ b/EXMP/LegalEntities/FinancialInstitutionExamples.rdf
@@ -172,6 +172,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/FinancialInstitutionExamples.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/FinancialInstitutionExamples.rdf version of the ontology was modified to merge details from the old corporations ontology into corporate bodies for consistency and useability (BE-259).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251001/https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/FinancialInstitutionExamples.rdf version of the ontology was modified to add individuals needed for the ACTUS challenge (SEC-215) and to move details for DJIA companies to a separate vocabulary (FND-407).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20260601/https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/FinancialInstitutionExamples.rdf version of the ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -181,7 +182,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Société Générale Plc legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Société Générale</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>213800O66553ESU7RD35</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>213800O66553ESU7RD35</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;SocieteGeneraleEntity"/>
 	</owl:NamedIndividual>
 	
@@ -189,7 +190,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>ING Bank NV legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for ING Bank NV</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3TK20IVIUJ8J3ZU0QE75</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3TK20IVIUJ8J3ZU0QE75</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;INGBankNV"/>
 	</owl:NamedIndividual>
 	
@@ -197,7 +198,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>BNY Mellon, National Association legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for BNY Mellon, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4EP6JBYBTPTQ47LZOB67</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4EP6JBYBTPTQ47LZOB67</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BNYMellonNationalAssociation-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -205,7 +206,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Morgan Stanley &amp; Co. International plc legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Morgan Stanley &amp; Co. International plc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4PQUHN3JPFGFNF3BB653</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4PQUHN3JPFGFNF3BB653</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;MorganStanleyAndCoInternationalPlc"/>
 	</owl:NamedIndividual>
 	
@@ -213,7 +214,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Standard Chartered Securities (North America) LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Standard Chartered Securities (North America) LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5493003GCX71N8988W38</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5493003GCX71N8988W38</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StandardCharteredSecuritiesNorthAmericaLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -221,7 +222,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>ABN AMRO Securities (USA) LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for ABN AMRO Securities (USA) LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300FIFV1CB6HD9A14</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300FIFV1CB6HD9A14</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;ABNAMROSecuritiesUSALLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -229,7 +230,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Citicorp LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Citicorp LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300PSHWOM1D1JVL23</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300PSHWOM1D1JVL23</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CiticorpLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -237,7 +238,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>BNP Paribas USA, INC. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for BNP Paribas USA, INC.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300QVEGJN81E8T563</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300QVEGJN81E8T563</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BNPParibasUSAINC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -245,7 +246,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>State Street Corporation legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for State Street Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300ZFEEJ2IP5VME73</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300ZFEEJ2IP5VME73</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StateStreetCorporation-US-MA"/>
 	</owl:NamedIndividual>
 	
@@ -253,7 +254,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>State Street Bank and Trust Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>571474TGEMMWANRLN572</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>571474TGEMMWANRLN572</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StateStreetBankAndTrustCompany-US-MA"/>
 	</owl:NamedIndividual>
 	
@@ -261,7 +262,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Citigroup Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Citigroup Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>6SHGI4ZSSLCXXQSBB395</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>6SHGI4ZSSLCXXQSBB395</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CitigroupInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -269,7 +270,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>FMR LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for FMR LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>6X064LF7Y6B4DKF2GZ26</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>6X064LF7Y6B4DKF2GZ26</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;FMRLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -277,7 +278,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>7H6GLXDRUGQFU57RNE97</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>7H6GLXDRUGQFU57RNE97</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociation-US"/>
 	</owl:NamedIndividual>
 	
@@ -285,7 +286,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Deutsche Bank Aktiengesellschaft legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Deutsche Bank Aktiengesellschaft</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>7LTWFZYICNSX8D621K86</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>7LTWFZYICNSX8D621K86</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;DeutscheBankAktiengesellschaft-DE"/>
 	</owl:NamedIndividual>
 	
@@ -293,7 +294,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Commerzbank AG legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Commerzbank AG</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>851WYGNLUQLFZBSYGB56</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>851WYGNLUQLFZBSYGB56</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CommerzbankAG"/>
 	</owl:NamedIndividual>
 	
@@ -301,7 +302,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for JPMorgan Chase &amp; Co.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>8I5DZWZKVSZI1NUHU748</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>8I5DZWZKVSZI1NUHU748</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganChaseAndCo-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -309,7 +310,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Morgan Stanley &amp; Co. LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Morgan Stanley &amp; Co. LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>9R7GPTSO7KV3UQJZQ078</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>9R7GPTSO7KV3UQJZQ078</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;MorganStanleyAndCoLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -317,7 +318,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Bank of America, National Association legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Bank of America, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>B4TYDEB6GKMZO031MB27</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>B4TYDEB6GKMZO031MB27</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BankOfAmericaNationalAssociation-US"/>
 	</owl:NamedIndividual>
 	
@@ -325,7 +326,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>ABN AMRO Bank N.V. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for ABN AMRO Bank N.V.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BFXS5XCH7N0Y05NIXW11</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BFXS5XCH7N0Y05NIXW11</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;ABNAMROBankNV"/>
 	</owl:NamedIndividual>
 	
@@ -333,7 +334,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Citibank, N.A. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Citibank N.A.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>E57ODZWZ7FF32TWEFA76</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>E57ODZWZ7FF32TWEFA76</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CitibankNA-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -341,7 +342,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Bank of America Europe legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Bank of America Europe Designated Activity Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>EQYXK86SF381Q21S3020</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>EQYXK86SF381Q21S3020</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BankOfAmericaEuropeEntity"/>
 	</owl:NamedIndividual>
 	
@@ -349,7 +350,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Goldman Sachs &amp; Co. LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Goldman Sachs &amp; Co. LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>FOR8UP27PHTHYVLBNG30</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>FOR8UP27PHTHYVLBNG30</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;GoldmanSachsAndCoLLC-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -357,7 +358,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Barclays Bank Plc legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Barclays Bank Plc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>G5GSEF7VJP5I7OUK5573</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>G5GSEF7VJP5I7OUK5573</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BarclaysBankPlc"/>
 	</owl:NamedIndividual>
 	
@@ -365,7 +366,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>JP Morgan Securities legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for JP Morgan Securities</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>K6Q0W1PS1L1O4IQL9C32</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>K6Q0W1PS1L1O4IQL9C32</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganSecuritiesPlc"/>
 	</owl:NamedIndividual>
 	
@@ -373,7 +374,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Wells Fargo Bank, National Association legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KB1H1DSPRFMYMCUFXT09</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>KB1H1DSPRFMYMCUFXT09</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;WellsFargoBankNationalAssociation-US"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -382,7 +383,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>WFC Holdings, LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for WFC Holdings, LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>OT19FZZ6Z7A27CCLDY33</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>OT19FZZ6Z7A27CCLDY33</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;WFCHoldingsLLC-US-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -391,7 +392,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Wells Fargo &amp; Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Wells Fargo &amp; Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PBLD0EJDB5FWOLXP3B76</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>PBLD0EJDB5FWOLXP3B76</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;WellsFargoAndCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -399,7 +400,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Standard Chartered Bank legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Standard Chartered Bank</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RILFO74KP1CM8P6PCT96</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>RILFO74KP1CM8P6PCT96</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StandardCharteredBankEntity"/>
 	</owl:NamedIndividual>
 	
@@ -407,7 +408,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>NatWest Markets Plc legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for NatWest Markets Plc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RR3QWICWWIPCS8A4S074</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>RR3QWICWWIPCS8A4S074</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;NatWestMarketsPlc"/>
 	</owl:NamedIndividual>
 	
@@ -415,7 +416,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>The Bank of New York Mellon Corporation legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Bank of New York Mellon Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WFLLPEPC7FZXENRZV188</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>WFLLPEPC7FZXENRZV188</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BankOfNewYorkMellonCorporation-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -584,7 +585,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>South Dakota Business Entity registration identifier for BNY Mellon, National Association</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate>1997-06-05</fibo-fbc-fct-breg:hasInitialRegistrationDate>
-		<fibo-fnd-rel-rel:hasTag>FK010222</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>FK010222</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BNYMellonNationalAssociation-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessInformationRegistry"/>
@@ -595,26 +596,26 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>BNY Mellon, National Association - Business Identifier Code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for BNY Mellon, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MELNUS3PXXX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-finst;BNYMellonNationalAssociationBusinessPartyPrefix"/>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-finst;BNYMellonNationalAssociationBusinessPartySuffix"/>
 		<cmns-col:comprises rdf:resource="&lcc-3166-1;US"/>
 		<cmns-cxtdsg:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-dsg:hasTag>MELNUS3PXXX</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BNYMellonNationalAssociation-US-DE"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;BNYMellonNationalAssociationBusinessPartyPrefix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>BNY Mellon, National Association business party prefix</rdfs:label>
-		<fibo-fnd-rel-rel:hasTag>MELN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-finst;BNYMellonNationalAssociationBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>MELN</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;BNYMellonNationalAssociationBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>BNY Mellon, National Association business party suffix</rdfs:label>
-		<fibo-fnd-rel-rel:hasTag>3P</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-finst;BNYMellonNationalAssociationBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>3P</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;BNYMellonNationalAssociationDateEstablished">
@@ -635,7 +636,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>BNY Mellon, National Association FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for BNY Mellon, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>7946</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>7946</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BNYMellonNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -655,7 +656,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>BNY Mellon, National Association RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to BNY Mellon, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>934329</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>934329</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BNYMellonNationalAssociation"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -664,7 +665,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>BNY Mellon, National Association RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for BNY Mellon, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>043019265</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>043019265</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BNYMellonNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -834,7 +835,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Bank of New York Mellon Corporation business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for the Bank of New York Mellon Corporation</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
-		<fibo-fnd-rel-rel:hasTag>4299124</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4299124</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BankOfNewYorkMellonCorporation-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -864,7 +865,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>Bank of New York Mellon Corporation RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to The Bank of New York Mellon Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3587146</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3587146</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;BankOfNewYorkMellonCorporation"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -963,7 +964,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for Citi Cards South Dakota Acceptance Corp.</skos:definition>
 		<fibo-be-le-cb:hasDateOfRegistration rdf:resource="&fibo-exmp-le-finst;CitiCardsSouthDakotaAcceptanceCorpIncorporationDate"/>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
-		<fibo-fnd-rel-rel:hasTag>3686137</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3686137</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CitiCardsSouthDakotaAcceptanceCorp-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -1002,7 +1003,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>Citi Cards South Dakota Acceptance Corp. RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Citi Cards South Dakota Acceptance Corp.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3225130</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3225130</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CitiCardsSouthDakotaAcceptanceCorp"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -1038,7 +1039,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for Citibank N.A.</skos:definition>
 		<fibo-be-le-cb:hasDateOfRegistration rdf:resource="&fibo-exmp-le-finst;CitibankNAIncorporationDate"/>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
-		<fibo-fnd-rel-rel:hasTag>944169</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>944169</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CitibankNA-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -1063,8 +1064,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>Citibank, N.A. FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for Citibank, N.A.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>7213</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:explanatoryNote>From the NIC and FDIC records, it appears that Citibank, National Association (with RSSD of 112855 and FDIC certificate of 16100) and Citibank, N.A. have been merged into a single national bank, with the surviving FDIC certificate and RSSD as defined herein.</cmns-av:explanatoryNote>
+		<cmns-dsg:hasTag>7213</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CitibankNA"/>
 	</owl:NamedIndividual>
 	
@@ -1123,8 +1124,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>Citibank, N.A. RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Citibank, N.A.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>476810</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:explanatoryNote>From the NIC and FDIC records, it appears that Citibank, National Association (with RSSD of 112855 and FDIC certificate of 16100) and Citibank, N.A. have been merged into a single national bank, with the surviving FDIC certificate and RSSD as defined herein.</cmns-av:explanatoryNote>
+		<cmns-dsg:hasTag>476810</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CitibankNA"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -1133,7 +1134,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>Citibank, N.A. RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for Citibank, N.A.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>021000089</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>021000089</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CitibankNA"/>
 	</owl:NamedIndividual>
 	
@@ -1161,7 +1162,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>Citicorp LLC business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for Citicorp LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3911630</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3911630</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CiticorpLLC-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -1194,7 +1195,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>Citicorp LLC RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Citicorp LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3375370</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3375370</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CiticorpLLC"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -1235,7 +1236,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>Citigroup Inc. business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for Citigroup Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>2154254</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>2154254</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CitigroupInc-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -1276,7 +1277,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>Citigroup Inc. RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Citigroup Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>1951350</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>1951350</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;CitigroupInc"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -1367,7 +1368,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>FMR LLC business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for FMR LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4403845</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4403845</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;FMRLLC-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -1408,7 +1409,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>FMR LLC RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to FMR LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>1245983</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>1245983</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;FMRLLC"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -1505,7 +1506,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>JPMorgan Chase &amp; Co. business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for JPMorgan Chase &amp; Co.</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
-		<fibo-fnd-rel-rel:hasTag>691011</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>691011</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganChaseAndCo-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -1516,11 +1517,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. Business Identifier Code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for JPMorgan Chase &amp; Co.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HAMQUS31XXX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-finst;JPMorganChaseAndCoBusinessPartyPrefix"/>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-finst;JPMorganChaseAndCoBusinessPartySuffix"/>
 		<cmns-col:comprises rdf:resource="&lcc-3166-1;US"/>
 		<cmns-cxtdsg:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-dsg:hasTag>HAMQUS31XXX</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganChaseAndCo-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1528,16 +1529,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. business party prefix</rdfs:label>
 		<skos:definition>business party prefix for JPMorgan Chase &amp; Co.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HAMQ</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-finst;JPMorganChaseAndCoBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>HAMQ</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;JPMorganChaseAndCoBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. business party suffix</rdfs:label>
 		<skos:definition>business party suffix for JPMorgan Chase &amp; Co.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>31</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-finst;JPMorganChaseAndCoBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>31</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;JPMorganChaseAndCoHeadquartersAddress">
@@ -1574,7 +1575,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to JPMorgan Chase &amp; Co.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>1039502</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>1039502</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganChaseAndCo"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -1621,7 +1622,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>JPMorgan Chase Bank, National Association business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Ohio Department of Corporations for JPMorgan Chase Bank, National Association</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
-		<fibo-fnd-rel-rel:hasTag>2118141</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>2118141</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociation-US"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal"/>
@@ -1632,11 +1633,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association - business identifier code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHASUS33XXX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociationBusinessPartyPrefix"/>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociationBusinessPartySuffix"/>
 		<cmns-col:comprises rdf:resource="&lcc-3166-1;US"/>
 		<cmns-cxtdsg:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-dsg:hasTag>CHASUS33XXX</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociation-US"/>
 	</owl:NamedIndividual>
 	
@@ -1644,16 +1645,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association business party prefix</rdfs:label>
 		<skos:definition>business party prefix for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHAS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociationBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>CHAS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociationBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association business party suffix</rdfs:label>
 		<skos:definition>business party suffix for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>33</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociationBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>33</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociationDateEstablished">
@@ -1674,7 +1675,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>628</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>628</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -1694,7 +1695,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>852218</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>852218</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociation"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -1703,7 +1704,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>021000021</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>021000021</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;JPMorganChaseBankNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -1984,7 +1985,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Pinnacle Bank business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the California Division of Corporations for Pinnacle Bank</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
-		<fibo-fnd-rel-rel:hasTag>C2859719</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>C2859719</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;PinnacleBank-US-CA"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessEntitiesRegistry"/>
@@ -2003,7 +2004,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-law-lcap;LicenseIdentifier"/>
 		<rdfs:label>Pinnacle Bank California Certificate of Authority identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the California Department of Business Oversight for the California Certificate of Authority (banking license) for Pinnacle Bank</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>2261</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>2261</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;PinnacleBankCaliforniaCertificateOfAuthority"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBankingRegulator"/>
 	</owl:NamedIndividual>
@@ -2019,7 +2020,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>Pinnacle Bank FDIC Certificate</rdfs:label>
 		<skos:definition>FDIC Certificate number for Pinnacle Bank</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>58297</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>58297</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;PinnacleBank"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;FDICInstitutionDirectory"/>
 	</owl:NamedIndividual>
@@ -2051,7 +2052,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>Pinnacle Bank RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Pinnacle Bank</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3455227</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3455227</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;PinnacleBank"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -2060,7 +2061,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>Pinnacle Bank RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for Pinnacle Bank</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>121144340</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>121144340</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;PinnacleBank"/>
 	</owl:NamedIndividual>
 	
@@ -2217,7 +2218,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>State Street Bank and Trust Company business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Massachusetts Corporations Division for State Street Bank and Trust Company</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
-		<fibo-fnd-rel-rel:hasTag>00011313</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>00011313</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StateStreetBankAndTrustCompany-US-MA"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsCorporationRegistry"/>
@@ -2228,11 +2229,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>State Street Bank and Trust Company - business identifier code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SBOSUS33XXX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-finst;StateStreetBankAndTrustCompanyBusinessPartyPrefix"/>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-finst;StateStreetBankAndTrustCompanyBusinessPartySuffix"/>
 		<cmns-col:comprises rdf:resource="&lcc-3166-1;US"/>
 		<cmns-cxtdsg:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-dsg:hasTag>SBOSUS33XXX</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StateStreetBankAndTrustCompany-US-MA"/>
 	</owl:NamedIndividual>
 	
@@ -2240,16 +2241,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>State Street Bank and Trust Company business party prefix</rdfs:label>
 		<skos:definition>business party prefix for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SBOS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-finst;StateStreetBankAndTrustCompanyBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>SBOS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;StateStreetBankAndTrustCompanyBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>State Street Bank and Trust Company business party suffix</rdfs:label>
 		<skos:definition>business party suffix for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>33</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-finst;StateStreetBankAndTrustCompanyBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>33</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;StateStreetBankAndTrustCompanyDateEstablished">
@@ -2270,7 +2271,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>State Street Bank and Trust Company FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>14</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>14</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StateStreetBankAndTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -2290,7 +2291,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>State Street Bank and Trust Company RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>35301</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>35301</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StateStreetBankAndTrustCompany"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -2299,7 +2300,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>State Street Bank and Trust Company RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>011000028</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>011000028</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StateStreetBankAndTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -2336,7 +2337,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>State Street Corporation business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Massachusetts Corporations Division for State Street Corporation</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
-		<fibo-fnd-rel-rel:hasTag>042456637</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>042456637</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StateStreetCorporation-US-MA"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsCorporationRegistry"/>
@@ -2377,7 +2378,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>State Street Corporation RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to State Street Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>1111435</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>1111435</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;StateStreetCorporation"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -2409,7 +2410,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>WFC Holdings, LLC business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for WFC Holdings, LLC</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
-		<fibo-fnd-rel-rel:hasTag>2939552</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>2939552</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;WFCHoldingsLLC-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -2484,7 +2485,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Wells Fargo &amp; Company business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for Wells Fargo &amp; Company</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
-		<fibo-fnd-rel-rel:hasTag>637901</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>637901</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;WellsFargoAndCompany-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -2526,7 +2527,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>Wells Fargo &amp; Company RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Wells Fargo &amp; Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>1120754</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>1120754</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;WellsFargoAndCompany"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -2558,11 +2559,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessIdentifierCode"/>
 		<rdfs:label>Wells Fargo Bank, National Association - business identifier code (BIC)</rdfs:label>
 		<skos:definition>business identifier code (BIC) for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WFBIUS6SXXX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-finst;WellsFargoBankNationalAssociationBusinessPartyPrefix"/>
 		<cmns-col:comprises rdf:resource="&fibo-exmp-le-finst;WellsFargoBankNationalAssociationBusinessPartySuffix"/>
 		<cmns-col:comprises rdf:resource="&lcc-3166-1;US"/>
 		<cmns-cxtdsg:appliesTo rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<cmns-dsg:hasTag>WFBIUS6SXXX</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;WellsFargoBankNationalAssociation-US"/>
 	</owl:NamedIndividual>
 	
@@ -2570,16 +2571,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>Wells Fargo Bank, National Association business party prefix</rdfs:label>
 		<skos:definition>business party prefix for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WFBI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-finst;WellsFargoBankNationalAssociationBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>WFBI</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;WellsFargoBankNationalAssociationBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>Wells Fargo Bank, National Association business party suffix</rdfs:label>
 		<skos:definition>business party suffix for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>6S</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isIncludedIn rdf:resource="&fibo-exmp-le-finst;WellsFargoBankNationalAssociationBusinessIdentifierCode"/>
+		<cmns-dsg:hasTag>6S</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-exmp-le-finst;WellsFargoBankNationalAssociationDateEstablished">
@@ -2600,7 +2601,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>Wells Fargo Bank, National Association FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3511</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3511</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;WellsFargoBankNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -2652,7 +2653,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>Wells Fargo Bank, National Association RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>451965</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>451965</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;WellsFargoBankNationalAssociation"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -2661,7 +2662,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>Wells Fargo Bank, National Association RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>121000248</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>121000248</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-finst;WellsFargoBankNationalAssociation"/>
 	</owl:NamedIndividual>
 

--- a/EXMP/LegalEntities/MarketsAndExchangesExamples.rdf
+++ b/EXMP/LegalEntities/MarketsAndExchangesExamples.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
@@ -38,6 +39,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/EXMP/LegalEntities/MarketsAndExchangesExamples/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
@@ -104,6 +106,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
@@ -111,8 +114,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/EXMP/20260601/LegalEntities/MarketsAndExchangesExamples/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/EXMP/20260701/LegalEntities/MarketsAndExchangesExamples/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20240101/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/EXMP/20260601/LegalEntities/MarketsAndExchangesExamples.rdf version of the ontology was modified to reflect migration of additional properties to OMG Commons v1.3 (FND-412).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180901/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/ version of this ontology was modified to support revisions of the MIC codes as of 11 January 2019, including the new URI strategy, and to move the registry definitions to a new international financial organizations ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/ version of this ontology was modified to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
@@ -134,7 +138,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>CBOE Global Markets, Inc. business entity identifier</rdfs:label>
 		<skos:definition>Delaware Division of Corporations business entity identifier for CBOE Global Markets, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4205301</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4205301</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-mktex;CBOEGlobalMarketsInc-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
@@ -239,7 +243,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>NYSE American Options, LLC business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Division of Corporations business entity identifier for NYSE American Options LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4982468</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4982468</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-mktex;NYSEAmericanOptionsLLC-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
@@ -290,7 +294,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>NYSE Arca, Inc. business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Division of Corporations business entity identifier for NYSE Arca, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>787634</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>787634</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-mktex;NYSEArcaInc-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
@@ -315,7 +319,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>NYSE Arca Holdings, Inc. business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Division of Corporations business entity identifier for NYSE Arca Holdings, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3703898</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3703898</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-mktex;NYSEArcaHoldingsInc-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
@@ -396,7 +400,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>NYSE Group, Inc. business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Division of Corporations business entity identifier for NYSE Group, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4160866</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4160866</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-mktex;NYSEGroupInc-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
@@ -432,7 +436,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>NYSE Holdings LLC business entity identifier</rdfs:label>
 		<skos:definition>Delaware Division of Corporations business entity identifier for NYSE Holdings LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5257784</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5257784</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-mktex;NYSEHoldingsLLC-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
@@ -512,7 +516,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>New York Stock Exchange LLC business entity identifier</rdfs:label>
 		<skos:definition>the New York Department of State Division of Corporations business entity identifier for New York Stock Exchange LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3230916</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3230916</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-mktex;NewYorkStockExchangeLLC-US-NY"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
@@ -553,7 +557,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>United Agent Group Inc. US-DE business entity identifier</rdfs:label>
 		<skos:definition>Delaware Department of Corporations business entity identifier for the United Agent Group Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5991300</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5991300</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-mktex;UnitedAgentGroupInc-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
@@ -583,7 +587,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>United Agent Group Inc. US-NY business entity identifier</rdfs:label>
 		<skos:definition>New York Department of State Division of Corporations business entity identifier for the United Agent Group Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4914572</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4914572</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-le-mktex;UnitedAgentGroupInc-US-NY"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>

--- a/EXMP/Securities/EquitiesExamples.rdf
+++ b/EXMP/Securities/EquitiesExamples.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
 	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
@@ -34,6 +35,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/EXMP/Securities/EquitiesExamples/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
 	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
@@ -95,10 +97,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20260601/Equities/EquitiesExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20260701/Equities/EquitiesExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquitiesExampleIndividuals.rdf version of this ontology was modified to add CFI codes to the example equity instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to add the share class to some of the examples, replace registered form with book entry (registered) form, and add detail to the common share and listing individuals.</skos:changeNote>
@@ -109,6 +112,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquitiesExampleIndividuals.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20240101/Equities/EquitiesExampleIndividuals.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20250301/Equities/EquitiesExampleIndividuals.rdf version of the ontology was modified to integrate migration of individuals to Commercial Registration Authorities (FND-407).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20260601/Equities/EquitiesExampleIndividuals.rdf version of the ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2019-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2019-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -139,9 +143,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>Alphabet Inc. class A financial instrument short name</rdfs:label>
 		<skos:definition>Alphabet Inc. class A common share financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ALPHABET INC/SH CL A</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH CL A</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>ALPHABET INC</fibo-sec-sec-iss:hasIssuerShortName>
+		<cmns-dsg:hasTag>ALPHABET INC/SH CL A</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -170,9 +174,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>Alphabet Inc. class C financial instrument short name</rdfs:label>
 		<skos:definition>Alphabet Inc. class C capital stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ALPHABET INC/SH CAP SH NV</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH CAP SH NV</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>ALPHABET INC</fibo-sec-sec-iss:hasIssuerShortName>
+		<cmns-dsg:hasTag>ALPHABET INC/SH CAP SH NV</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -209,9 +213,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>Apple Inc. common stock financial instrument short name</rdfs:label>
 		<skos:definition>Apple Inc. common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>APPLE INC/SH SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>APPLE INC</fibo-sec-sec-iss:hasIssuerShortName>
+		<cmns-dsg:hasTag>APPLE INC/SH SH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -227,7 +231,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000B9Y5X2</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Apple Inc. common shares listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000B9Y5X2</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG000B9Y5X2</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNASListedAppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -235,7 +239,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000BKZDM1</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Home Depot common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000BKZDM1</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG000BKZDM1</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedTheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -243,7 +247,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000BLNQ16</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for IBM common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000BLNQ16</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG000BLNQ16</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedInternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -251,7 +255,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000BMX4N8</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Coca-Cola Company common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000BMX4N8</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG000BMX4N8</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedTheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -259,7 +263,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000BR2WS4</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Proctor &amp; Gamble Company common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000BR2WS4</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG000BR2WS4</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedTheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -267,7 +271,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000BWQFY7</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Wells Fargo &amp; Company common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000BWQFY7</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG000BWQFY7</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedWellsFargoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -275,7 +279,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000DMBZW1</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for JPMorgan Chase &amp; Co. common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000DMBZW1</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG000DMBZW1</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedJPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -283,7 +287,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000FY4VG8</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Citigroup Inc. common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000FY4VG8</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG000FY4VG8</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedCitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -291,7 +295,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5MQ8</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Coca-Cola Company common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5MQ8</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG001S5MQ8</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -299,7 +303,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5N8V8</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Apple Inc. common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5N8V8</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG001S5N8V8</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -307,7 +311,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5RTW7</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Home Depot, Inc. common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5RTW7</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG001S5RTW7</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -315,7 +319,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5S399</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for IBM common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5S399</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG001S5S399</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;InternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -323,7 +327,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5V4L9</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Proctor &amp; Gamble Company common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5V4L9</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG001S5V4L9</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -331,7 +335,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5XF23</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Wells Fargo &amp; Company common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5XF23</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG001S5XF23</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;WellsFargoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -339,7 +343,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S72ZG4</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Citigroup Inc. common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S72ZG4</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG001S72ZG4</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;CitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -347,7 +351,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S8CRC3</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for JPMorgan Chase &amp; Co. common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S8CRC3</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG001S8CRC3</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;JPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -355,7 +359,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG009S39JY5</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Alphabet Inc. class A common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG009S39JY5</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG009S39JY5</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -363,7 +367,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG009S3NB21</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Alphabet Inc. class C common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG009S3NB21</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG009S3NB21</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -371,7 +375,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG009S4MT03</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Alphabet Inc. class A common shares listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG009S4MT03</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG009S4MT03</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNASListedAlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -379,7 +383,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG009S4MVF2</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Alphabet Inc. class C common shares listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG009S4MVF2</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG009S4MVF2</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNASListedAlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -387,7 +391,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG00JPR0LX8</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Apple Inc. common shares listed in the London Stock Exchange</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG00JPR0LX8</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>BBG00JPR0LX8</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XLOMListedAppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -395,7 +399,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>02079K107</rdfs:label>
 		<skos:definition>Alphabet Inc. class C common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>02079K107</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>02079K107</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -403,7 +407,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>02079K305</rdfs:label>
 		<skos:definition>Alphabet Inc. class A common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>02079K305</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>02079K305</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -411,7 +415,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>037833100</rdfs:label>
 		<skos:definition>Apple Inc. common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>037833100</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>037833100</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -419,7 +423,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>172967424</rdfs:label>
 		<skos:definition>Citigroup Inc. common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>172967424</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>172967424</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;CitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -427,7 +431,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>191216100</rdfs:label>
 		<skos:definition>The Coca-Cola Company common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>191216100</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>191216100</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -435,7 +439,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>437076102</rdfs:label>
 		<skos:definition>The Home Depot, Inc. common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>437076102</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>437076102</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -443,7 +447,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>459200101</rdfs:label>
 		<skos:definition>IBM common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>459200101</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>459200101</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;InternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -451,7 +455,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>46625H100</rdfs:label>
 		<skos:definition>JPMorgan Chase &amp; Co. common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>46625H100</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>46625H100</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;JPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -459,7 +463,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>742718109</rdfs:label>
 		<skos:definition>The Proctor &amp; Gamble Company common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>742718109</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>742718109</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -467,7 +471,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>949746101</rdfs:label>
 		<skos:definition>Wells Fargo &amp; Company common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>949746101</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>949746101</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;WellsFargoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -496,9 +500,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>Citigroup Inc. common stock financial instrument short name</rdfs:label>
 		<skos:definition>Citigroup Inc. common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CITIGROUP INC/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>CITIGROUP INC</fibo-sec-sec-iss:hasIssuerShortName>
+		<cmns-dsg:hasTag>CITIGROUP INC/SH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;CitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -514,7 +518,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US02079K1079</rdfs:label>
 		<skos:definition>Alphabet Inc. class C common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US02079K1079</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>US02079K1079</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -522,7 +526,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US02079K3059</rdfs:label>
 		<skos:definition>Alphabet Inc. class A common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US02079K3059</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>US02079K3059</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -530,7 +534,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US0378331005</rdfs:label>
 		<skos:definition>Apple Inc. common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US0378331005</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>US0378331005</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -538,7 +542,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US1729674242</rdfs:label>
 		<skos:definition>Citigroup Inc. common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US1729674242</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>US1729674242</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;CitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -546,7 +550,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US1912161007</rdfs:label>
 		<skos:definition>The Coca-Cola Company common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US1912161007</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>US1912161007</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -554,7 +558,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US4370761029</rdfs:label>
 		<skos:definition>The Home Depot, Inc. common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US4370761029</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>US4370761029</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -562,7 +566,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US4592001014</rdfs:label>
 		<skos:definition>IBM common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US4592001014</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>US4592001014</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;InternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -570,7 +574,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US46625H1005</rdfs:label>
 		<skos:definition>JPMorgan Chase &amp; Co. common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US46625H1005</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>US46625H1005</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;JPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -578,7 +582,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US7427181091</rdfs:label>
 		<skos:definition>The Proctor &amp; Gamble Company common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US7427181091</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>US7427181091</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -586,7 +590,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US9497461015</rdfs:label>
 		<skos:definition>Wells Fargo &amp; Company common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US9497461015</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>US9497461015</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;WellsFargoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -614,9 +618,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>International Business Machines Corporation common stock financial instrument short name</rdfs:label>
 		<skos:definition>IBM common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>INTL BUS MACHIN/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>INTL BUS MACHIN</fibo-sec-sec-iss:hasIssuerShortName>
+		<cmns-dsg:hasTag>INTL BUS MACHIN/SH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;InternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -653,9 +657,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>J.P. Morgan Chase &amp; Co. common stock financial instrument short name</rdfs:label>
 		<skos:definition>J.P. Morgan Chase &amp; Co. common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>JPMORGAN CHASE/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>JPMORGAN CHASE</fibo-sec-sec-iss:hasIssuerShortName>
+		<cmns-dsg:hasTag>JPMORGAN CHASE/SH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;JPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -671,7 +675,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;StockExchangeDailyOfficialListCode"/>
 		<rdfs:label>B0YQ5W0</rdfs:label>
 		<skos:definition>Apple Inc. common share SEDOL listed in the London Stock Exchange</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>B0YQ5W0</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>B0YQ5W0</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XLOMListedAppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -699,9 +703,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>The Coca-Cola Company common stock financial instrument short name</rdfs:label>
 		<skos:definition>The Coca-Cola Company common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>COCA COLA CO/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>COCA COLA CO</fibo-sec-sec-iss:hasIssuerShortName>
+		<cmns-dsg:hasTag>COCA COLA CO/SH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -738,9 +742,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>The Home Depot, Inc. common stock financial instrument short name</rdfs:label>
 		<skos:definition>Home Depot, Inc. common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HOME DEPOT INC/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>HOME DEPOT INC</fibo-sec-sec-iss:hasIssuerShortName>
+		<cmns-dsg:hasTag>HOME DEPOT INC/SH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -776,9 +780,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>The Proctor &amp; Gamble Company common stock financial instrument short name</rdfs:label>
 		<skos:definition>The Proctor &amp; Gamble Company common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PROCTER &amp; GAMBL/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>PROCTER &amp; GAMBL</fibo-sec-sec-iss:hasIssuerShortName>
+		<cmns-dsg:hasTag>PROCTER &amp; GAMBL/SH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;TheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -794,7 +798,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XLOM - 0R2V</rdfs:label>
 		<skos:definition>ticker symbol for Apple Inc. common stock listed in the London Stock Exchange</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>0R2V</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>0R2V</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XLOMListedAppleIncCommonStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-mkti;Facility-XLOM"/>
 	</owl:NamedIndividual>
@@ -803,7 +807,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XNAS - AAPL</rdfs:label>
 		<skos:definition>ticker symbol for Apple Inc. common stock listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AAPL</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>AAPL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNASListedAppleIncCommonStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-mkti;Facility-XNAS"/>
 	</owl:NamedIndividual>
@@ -812,7 +816,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XNAS - GOOG</rdfs:label>
 		<skos:definition>ticker symbol for Alphabet Inc. class C capital stock listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GOOG</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>GOOG</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNASListedAlphabetIncClassCCapitalStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-mkti;Facility-XNAS"/>
 	</owl:NamedIndividual>
@@ -821,7 +825,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XNAS - GOOGL</rdfs:label>
 		<skos:definition>ticker symbol for Alphabet Inc. class A common stock listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GOOGL</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>GOOGL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNASListedAlphabetIncClassACommonStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-mkti;Facility-XNAS"/>
 	</owl:NamedIndividual>
@@ -830,7 +834,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XNYS - C</rdfs:label>
 		<skos:definition>ticker symbol for Citigroup Inc. common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>C</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>C</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedCitigroupIncCommonStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-exmp-le-mktex;NewYorkStockExchange"/>
 	</owl:NamedIndividual>
@@ -839,7 +843,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XNYS - HD</rdfs:label>
 		<skos:definition>ticker symbol for The Home Depot, Inc. common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HD</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>HD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedTheHomeDepotIncCommonStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-exmp-le-mktex;NewYorkStockExchange"/>
 	</owl:NamedIndividual>
@@ -848,7 +852,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XNYS - IBM</rdfs:label>
 		<skos:definition>ticker symbol for Wells Fargo &amp; Company common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IBM</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>IBM</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedInternationalBusinessMachinesCorporationCommonStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-exmp-le-mktex;NewYorkStockExchange"/>
 	</owl:NamedIndividual>
@@ -857,7 +861,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XNYS - JPM</rdfs:label>
 		<skos:definition>ticker symbol for JPMorgan Chase &amp; Co. common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>JPM</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>JPM</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedJPMorganChaseAndCoCommonStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-exmp-le-mktex;NewYorkStockExchange"/>
 	</owl:NamedIndividual>
@@ -866,7 +870,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XNYS - KO</rdfs:label>
 		<skos:definition>ticker symbol for The Coca-Cola Company common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KO</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>KO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedTheCoca-ColaCompanyCommonStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-exmp-le-mktex;NewYorkStockExchange"/>
 	</owl:NamedIndividual>
@@ -875,7 +879,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XNYS - PG</rdfs:label>
 		<skos:definition>ticker symbol for The Proctor &amp; Gamble Company common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PG</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>PG</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedTheProctorAndGambleCompanyCommonStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-exmp-le-mktex;NewYorkStockExchange"/>
 	</owl:NamedIndividual>
@@ -884,7 +888,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;TickerSymbol"/>
 		<rdfs:label>XNYS - WFC</rdfs:label>
 		<skos:definition>ticker symbol for Wells Fargo &amp; Company common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WFC</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>WFC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-eqex;XNYSListedWellsFargoCommonStock"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-exmp-le-mktex;NewYorkStockExchange"/>
 	</owl:NamedIndividual>

--- a/EXMP/Securities/IRSwapExamples.rdf
+++ b/EXMP/Securities/IRSwapExamples.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
@@ -39,6 +40,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
@@ -105,6 +107,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
@@ -116,7 +119,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230201/Securities/IRSwapExamples.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20230301/Securities/IRSwapExamples.rdf version of the ontology was modified to replace concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20231201/Securities/IRSwapExamples.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20250301/Securities/IRSwapExamples.rdf version of the ontology was modified to move examples from their original locations to the EXMP module (FND-407) and reflect the move of the definition of portfolio to FND ownership (SEC-219).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20250301/Securities/IRSwapExamples.rdf version of the ontology was modified to move examples from their original locations to the EXMP module (FND-407), reflect the move of the definition of portfolio to FND ownership (SEC-219), and use Commons 1.3 properties rather than deprectated properties from FND (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -247,7 +250,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>ZZ216659451</rdfs:label>
 		<skos:definition>ISIN for sample swap contract IY7VKEUR45886</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ZZ216659451</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>ZZ216659451</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-irsex;Contract-IY7VKEUR45886"/>
 	</owl:NamedIndividual>
 	
@@ -255,7 +258,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-der-drc-swp;UniqueSwapIdentifier"/>
 		<rdfs:label>IY7VKEUR45886</rdfs:label>
 		<skos:definition>unique swap identifier for sample swap contract IY7VKEUR45886</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IY7VKEUR45886</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>IY7VKEUR45886</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-exmp-sec-irsex;Contract-IY7VKEUR45886"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/BusinessCentersIndividuals.rdf
+++ b/FBC/FunctionalEntities/BusinessCentersIndividuals.rdf
@@ -2,13 +2,13 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fct-bc "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/">
 	<!ENTITY fibo-fbc-fct-bci "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -20,13 +20,13 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fct-bc="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/"
 	xmlns:fibo-fbc-fct-bci="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -55,14 +55,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCenters/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260401/FunctionalEntities/BusinessCentersIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260701/FunctionalEntities/BusinessCentersIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180901/FunctionalEntities/BusinessCentersIndividuals/ version of this ontology was modified to support revisions of the MIC codes as of December 2018.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181201/FunctionalEntities/BusinessCentersIndividuals/ version of this ontology was modified to replace Swaziland with Eswatini, which was revised by the LCC 1.1 RTF to reflect the change to the country name per the U.N.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190401/FunctionalEntities/BusinessCentersIndividuals/ version of this ontology was modified to add municipalities required for the ISO revision to the MIC codes as of September 2019.</skos:changeNote>
@@ -88,6 +88,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250601/FunctionalEntities/BusinessCentersIndividuals.rdf version of this ontology was modified to update the business centers per the latest revision of the municipalities per the September 2025 ISO 10383 MIC code update from ISO.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251001/FunctionalEntities/BusinessCentersIndividuals.rdf version of this ontology was modified to update the business centers per the latest revision of the municipalities per the March 2026 ISO 10383 MIC code update from ISO.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20260401/FunctionalEntities/BusinessCentersIndividuals.rdf version of this ontology was modified to update the business centers per the latest revision of the municipalities per the June 2026 ISO 10383 MIC code update from ISO.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20260601/FunctionalEntities/BusinessCentersIndividuals.rdf version of this ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2018-2025 Object Management Group</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2018-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -101,8 +102,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessDayAdjustmentCode"/>
 		<rdfs:label>AEAB</rdfs:label>
 		<dct:description>the FpML business center code for Abu Dhabi, Business Day (as defined in 2021 ISDA Definitions Section 2.1.9 (ii))</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AEAB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AEAB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;AbuDhabiBusinessDay"/>
 	</owl:NamedIndividual>
 	
@@ -110,8 +111,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessDayAdjustmentCode"/>
 		<rdfs:label>AEAD</rdfs:label>
 		<dct:description>the FpML business center code for Abu Dhabi, Settlement Day (as defined in 2021 ISDA Definitions Section 2.1.9 (i))</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AEAD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AEAD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;AbuDhabiSettlementDay"/>
 	</owl:NamedIndividual>
 	
@@ -119,8 +120,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AEDU</rdfs:label>
 		<dct:description>the FpML business center code for Dubai, United Arab Emirates</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AEDU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AEDU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Dubai"/>
 	</owl:NamedIndividual>
 	
@@ -128,8 +129,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AMYE</rdfs:label>
 		<dct:description>the FpML business center code for Yerevan, Armenia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AMYE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AMYE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Yerevan"/>
 	</owl:NamedIndividual>
 	
@@ -137,8 +138,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AOLU</rdfs:label>
 		<dct:description>the FpML business center code for Luanda, Angola</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AOLU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AOLU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Luanda"/>
 	</owl:NamedIndividual>
 	
@@ -146,8 +147,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ARBA</rdfs:label>
 		<dct:description>the FpML business center code for Buenos Aires, Argentina</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ARBA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ARBA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Buenos_Aires"/>
 	</owl:NamedIndividual>
 	
@@ -155,8 +156,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ATVI</rdfs:label>
 		<dct:description>the FpML business center code for Vienna, Austria</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ATVI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ATVI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Vienna"/>
 	</owl:NamedIndividual>
 	
@@ -164,8 +165,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AUAD</rdfs:label>
 		<dct:description>the FpML business center code for Adelaide, Australia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AUAD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AUAD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Adelaide"/>
 	</owl:NamedIndividual>
 	
@@ -173,8 +174,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AUBR</rdfs:label>
 		<dct:description>the FpML business center code for Brisbane, Australia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AUBR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AUBR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Brisbane"/>
 	</owl:NamedIndividual>
 	
@@ -182,8 +183,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AUCA</rdfs:label>
 		<dct:description>the FpML business center code for Canberra, Australia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AUCA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AUCA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Canberra"/>
 	</owl:NamedIndividual>
 	
@@ -191,8 +192,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AUDA</rdfs:label>
 		<dct:description>the FpML business center code for Darwin, Australia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AUDA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AUDA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Darwin"/>
 	</owl:NamedIndividual>
 	
@@ -200,8 +201,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AUME</rdfs:label>
 		<dct:description>the FpML business center code for Melbourne, Australia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AUME</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AUME</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Melbourne"/>
 	</owl:NamedIndividual>
 	
@@ -209,8 +210,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AUPE</rdfs:label>
 		<dct:description>the FpML business center code for Perth, Australia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AUPE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AUPE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Perth"/>
 	</owl:NamedIndividual>
 	
@@ -218,8 +219,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AUSY</rdfs:label>
 		<dct:description>the FpML business center code for Sydney, Australia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AUSY</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AUSY</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Sydney"/>
 	</owl:NamedIndividual>
 	
@@ -227,8 +228,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>AZBA</rdfs:label>
 		<dct:description>the FpML business center code for Baku, Azerbaijan</dct:description>
-		<fibo-fnd-rel-rel:hasTag>AZBA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>AZBA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Baku"/>
 	</owl:NamedIndividual>
 	
@@ -421,8 +422,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BBBR</rdfs:label>
 		<dct:description>the FpML business center code for Bridgetown, Barbados</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BBBR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BBBR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Bridgetown"/>
 	</owl:NamedIndividual>
 	
@@ -430,8 +431,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BDDH</rdfs:label>
 		<dct:description>the FpML business center code for Dhaka, Bangladesh</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BDDH</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BDDH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Dhaka"/>
 	</owl:NamedIndividual>
 	
@@ -439,8 +440,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BEBR</rdfs:label>
 		<dct:description>the FpML business center code for Brussels, Belgium</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BEBR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BEBR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Brussels"/>
 	</owl:NamedIndividual>
 	
@@ -448,8 +449,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BGSO</rdfs:label>
 		<dct:description>the FpML business center code for Sofia, Bulgaria</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BGSO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BGSO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Sofia"/>
 	</owl:NamedIndividual>
 	
@@ -457,8 +458,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BHMA</rdfs:label>
 		<dct:description>the FpML business center code for Manama, Bahrain</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BHMA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BHMA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Manama"/>
 	</owl:NamedIndividual>
 	
@@ -466,8 +467,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BMHA</rdfs:label>
 		<dct:description>the FpML business center code for Hamilton, Bermuda</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BMHA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BMHA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Hamilton"/>
 	</owl:NamedIndividual>
 	
@@ -475,8 +476,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BNBS</rdfs:label>
 		<dct:description>the FpML business center code for Bandar Seri Begawan, Brunei</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BNBS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BNBS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Bandar_Seri_Begawan"/>
 	</owl:NamedIndividual>
 	
@@ -484,8 +485,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BOLP</rdfs:label>
 		<dct:description>the FpML business center code for La Paz, Bolivia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BOLP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BOLP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;La_Paz"/>
 	</owl:NamedIndividual>
 	
@@ -493,8 +494,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessDayAdjustmentCode"/>
 		<rdfs:label>BRBD</rdfs:label>
 		<dct:description>the FpML business center code for Brazil Business Day</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BRBD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BRBD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;BrazilBusinessDay"/>
 	</owl:NamedIndividual>
 	
@@ -502,8 +503,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BRBR</rdfs:label>
 		<dct:description>the FpML business center code for Brasilia, Brazil</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BRBR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BRBR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Brasilia"/>
 	</owl:NamedIndividual>
 	
@@ -511,8 +512,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BRRJ</rdfs:label>
 		<dct:description>the FpML business center code for Rio de Janeiro, Brazil</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BRRJ</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BRRJ</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Rio_de_Janeiro"/>
 	</owl:NamedIndividual>
 	
@@ -520,8 +521,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BRSP</rdfs:label>
 		<dct:description>the FpML business center code for Sao Paulo, Brazil</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BRSP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BRSP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Sao_Paulo"/>
 	</owl:NamedIndividual>
 	
@@ -529,8 +530,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BSNA</rdfs:label>
 		<dct:description>the FpML business center code for Nassau, Bahamas</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BSNA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BSNA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Nassau"/>
 	</owl:NamedIndividual>
 	
@@ -538,8 +539,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BWGA</rdfs:label>
 		<dct:description>the FpML business center code for Gaborone, Botswana</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BWGA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BWGA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Gaborone"/>
 	</owl:NamedIndividual>
 	
@@ -547,8 +548,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>BYMI</rdfs:label>
 		<dct:description>the FpML business center code for Minsk, Belarus</dct:description>
-		<fibo-fnd-rel-rel:hasTag>BYMI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>BYMI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Minsk"/>
 	</owl:NamedIndividual>
 	
@@ -838,8 +839,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CACL</rdfs:label>
 		<dct:description>the FpML business center code for Calgary, Canada</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CACL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CACL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Calgary"/>
 	</owl:NamedIndividual>
 	
@@ -847,8 +848,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CAFR</rdfs:label>
 		<dct:description>the FpML business center code for Fredericton, Canada</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CAFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CAFR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Fredericton"/>
 	</owl:NamedIndividual>
 	
@@ -856,8 +857,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CAMO</rdfs:label>
 		<dct:description>the FpML business center code for Montreal, Canada</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CAMO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CAMO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Montreal"/>
 	</owl:NamedIndividual>
 	
@@ -865,8 +866,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CAOT</rdfs:label>
 		<dct:description>the FpML business center code for Ottawa, Canada</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CAOT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CAOT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Ottawa"/>
 	</owl:NamedIndividual>
 	
@@ -874,8 +875,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CATO</rdfs:label>
 		<dct:description>the FpML business center code for Toronto, Canada</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CATO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CATO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Toronto"/>
 	</owl:NamedIndividual>
 	
@@ -883,8 +884,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CAVA</rdfs:label>
 		<dct:description>the FpML business center code for Vancouver, Canada</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CAVA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CAVA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Vancouver"/>
 	</owl:NamedIndividual>
 	
@@ -892,8 +893,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CAWI</rdfs:label>
 		<dct:description>the FpML business center code for Winnipeg, Canada</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CAWI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CAWI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Winnipeg"/>
 	</owl:NamedIndividual>
 	
@@ -901,8 +902,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CHBA</rdfs:label>
 		<dct:description>the FpML business center code for Basel, Switzerland</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CHBA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CHBA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Basel"/>
 	</owl:NamedIndividual>
 	
@@ -910,8 +911,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CHGE</rdfs:label>
 		<dct:description>the FpML business center code for Geneva, Switzerland</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CHGE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CHGE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Geneva"/>
 	</owl:NamedIndividual>
 	
@@ -919,8 +920,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CHZU</rdfs:label>
 		<dct:description>the FpML business center code for Zurich, Switzerland</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CHZU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CHZU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Zurich"/>
 	</owl:NamedIndividual>
 	
@@ -928,8 +929,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CIAB</rdfs:label>
 		<dct:description>the FpML business center code for Abidjan, Cote d&apos;Ivoire</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CIAB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CIAB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Abidjan"/>
 	</owl:NamedIndividual>
 	
@@ -937,8 +938,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CLSA</rdfs:label>
 		<dct:description>the FpML business center code for Santiago, Chile</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CLSA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CLSA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Santiago"/>
 	</owl:NamedIndividual>
 	
@@ -946,8 +947,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CMYA</rdfs:label>
 		<dct:description>the FpML business center code for Yaounde, Cameroon</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CMYA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CMYA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Yaounde"/>
 	</owl:NamedIndividual>
 	
@@ -955,8 +956,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CNBE</rdfs:label>
 		<dct:description>the FpML business center code for Beijing, China</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CNBE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CNBE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Beijing"/>
 	</owl:NamedIndividual>
 	
@@ -964,8 +965,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CNSH</rdfs:label>
 		<dct:description>the FpML business center code for Shanghai, China</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CNSH</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CNSH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Shanghai"/>
 	</owl:NamedIndividual>
 	
@@ -973,8 +974,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>COBO</rdfs:label>
 		<dct:description>the FpML business center code for Bogota, Colombia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>COBO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>COBO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Bogota"/>
 	</owl:NamedIndividual>
 	
@@ -982,8 +983,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CRSJ</rdfs:label>
 		<dct:description>the FpML business center code for San Jose, Costa Rica</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CRSJ</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CRSJ</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;San_Jose"/>
 	</owl:NamedIndividual>
 	
@@ -991,8 +992,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CWWI</rdfs:label>
 		<dct:description>the FpML business center code for Willemstad, Curacao</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CWWI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CWWI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Willemstad"/>
 	</owl:NamedIndividual>
 	
@@ -1000,8 +1001,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CYNI</rdfs:label>
 		<dct:description>the FpML business center code for Nicosia, Cyprus</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CYNI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CYNI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Nicosia"/>
 	</owl:NamedIndividual>
 	
@@ -1009,8 +1010,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>CZPR</rdfs:label>
 		<dct:description>the FpML business center code for Prague, Czech Republic</dct:description>
-		<fibo-fnd-rel-rel:hasTag>CZPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>CZPR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Prague"/>
 	</owl:NamedIndividual>
 	
@@ -1162,8 +1163,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DECO</rdfs:label>
 		<dct:description>the FpML business center code for Cologne, Germany</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DECO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DECO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Cologne"/>
 	</owl:NamedIndividual>
 	
@@ -1171,8 +1172,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DEDU</rdfs:label>
 		<dct:description>the FpML business center code for Dusseldorf, Germany</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DEDU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DEDU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Dusseldorf"/>
 	</owl:NamedIndividual>
 	
@@ -1180,8 +1181,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DEFR</rdfs:label>
 		<dct:description>the FpML business center code for Frankfurt, Germany</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DEFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DEFR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Frankfurt"/>
 	</owl:NamedIndividual>
 	
@@ -1189,8 +1190,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DEHA</rdfs:label>
 		<dct:description>the FpML business center code for Hannover, Germany</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DEHA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DEHA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Hannover"/>
 	</owl:NamedIndividual>
 	
@@ -1198,8 +1199,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DEHH</rdfs:label>
 		<dct:description>the FpML business center code for Hamburg, Germany</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DEHH</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DEHH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Hamburg"/>
 	</owl:NamedIndividual>
 	
@@ -1207,8 +1208,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DELE</rdfs:label>
 		<dct:description>the FpML business center code for Leipzig, Germany</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DELE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DELE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Leipzig"/>
 	</owl:NamedIndividual>
 	
@@ -1216,8 +1217,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DEMA</rdfs:label>
 		<dct:description>the FpML business center code for Mainz, Germany</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DEMA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DEMA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Mainz"/>
 	</owl:NamedIndividual>
 	
@@ -1225,8 +1226,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DEMU</rdfs:label>
 		<dct:description>the FpML business center code for Munich, Germany</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DEMU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DEMU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Munich"/>
 	</owl:NamedIndividual>
 	
@@ -1234,8 +1235,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DEST</rdfs:label>
 		<dct:description>the FpML business center code for Stuttgart, Germany</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DEST</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DEST</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Stuttgart"/>
 	</owl:NamedIndividual>
 	
@@ -1243,8 +1244,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DKCO</rdfs:label>
 		<dct:description>the FpML business center code for Copenhagen, Denmark</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DKCO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DKCO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Copenhagen"/>
 	</owl:NamedIndividual>
 	
@@ -1252,8 +1253,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DOSD</rdfs:label>
 		<dct:description>the FpML business center code for Santo Domingo, Dominican Republic</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DOSD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DOSD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Santo_Domingo"/>
 	</owl:NamedIndividual>
 	
@@ -1261,8 +1262,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>DZAL</rdfs:label>
 		<dct:description>the FpML business center code for Algiers, Algeria</dct:description>
-		<fibo-fnd-rel-rel:hasTag>DZAL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>DZAL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Algiers"/>
 	</owl:NamedIndividual>
 	
@@ -1383,8 +1384,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ECGU</rdfs:label>
 		<dct:description>the FpML business center code for Guayaquil, Ecuador</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ECGU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ECGU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Guayaquil"/>
 	</owl:NamedIndividual>
 	
@@ -1392,8 +1393,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>EETA</rdfs:label>
 		<dct:description>the FpML business center code for Tallinn, Estonia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>EETA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>EETA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Tallinn"/>
 	</owl:NamedIndividual>
 	
@@ -1401,8 +1402,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>EGCA</rdfs:label>
 		<dct:description>the FpML business center code for Cairo, Egypt</dct:description>
-		<fibo-fnd-rel-rel:hasTag>EGCA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>EGCA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Cairo"/>
 	</owl:NamedIndividual>
 	
@@ -1410,8 +1411,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessDayAdjustmentCode"/>
 		<rdfs:label>ESAS</rdfs:label>
 		<dct:description>the FpML business center code for ESAS Settlement Day (as defined in 2006 ISDA Definitions Section 7.1 and Supplement Number 15 to the 2000 ISDA Definitions)</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ESAS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ESAS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;ESASSettlementDay"/>
 	</owl:NamedIndividual>
 	
@@ -1427,8 +1428,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ESBA</rdfs:label>
 		<dct:description>the FpML business center code for Barcelona, Spain</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ESBA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ESBA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Barcelona"/>
 	</owl:NamedIndividual>
 	
@@ -1436,8 +1437,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ESMA</rdfs:label>
 		<dct:description>the FpML business center code for Madrid, Spain</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ESMA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ESMA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Madrid"/>
 	</owl:NamedIndividual>
 	
@@ -1445,8 +1446,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ESSS</rdfs:label>
 		<dct:description>the FpML business center code for San Sebastian, Spain</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ESSS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ESSS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;San_Sebastian"/>
 	</owl:NamedIndividual>
 	
@@ -1454,8 +1455,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ETAA</rdfs:label>
 		<dct:description>the FpML business center code for Addis Ababa, Ethiopia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ETAA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ETAA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Addis_Ababa"/>
 	</owl:NamedIndividual>
 	
@@ -1463,8 +1464,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessDayAdjustmentCode"/>
 		<rdfs:label>EUTA</rdfs:label>
 		<dct:description>the FpML business center code for TARGET Settlement Day</dct:description>
-		<fibo-fnd-rel-rel:hasTag>EUTA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>EUTA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;TARGETSettlementDay"/>
 	</owl:NamedIndividual>
 	
@@ -1527,8 +1528,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>FIHE</rdfs:label>
 		<dct:description>the FpML business center code for Helsinki, Finland</dct:description>
-		<fibo-fnd-rel-rel:hasTag>FIHE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>FIHE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Helsinki"/>
 	</owl:NamedIndividual>
 	
@@ -1536,8 +1537,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>FRPA</rdfs:label>
 		<dct:description>the FpML business center code for Paris, France</dct:description>
-		<fibo-fnd-rel-rel:hasTag>FRPA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>FRPA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Paris"/>
 	</owl:NamedIndividual>
 	
@@ -1597,8 +1598,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>GBED</rdfs:label>
 		<dct:description>the FpML business center code for Edinburgh, Scotland</dct:description>
-		<fibo-fnd-rel-rel:hasTag>GBED</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>GBED</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Edinburgh"/>
 	</owl:NamedIndividual>
 	
@@ -1606,8 +1607,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>GBLO</rdfs:label>
 		<dct:description>the FpML business center code for London, United Kingdom</dct:description>
-		<fibo-fnd-rel-rel:hasTag>GBLO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>GBLO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;London"/>
 	</owl:NamedIndividual>
 	
@@ -1615,8 +1616,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>GETB</rdfs:label>
 		<dct:description>the FpML business center code for Tbilisi, Georgia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>GETB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>GETB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Tbilisi"/>
 	</owl:NamedIndividual>
 	
@@ -1624,8 +1625,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>GGSP</rdfs:label>
 		<dct:description>the FpML business center code for Saint Peter Port, Guernsey</dct:description>
-		<fibo-fnd-rel-rel:hasTag>GGSP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>GGSP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Saint_Peter_Port"/>
 	</owl:NamedIndividual>
 	
@@ -1633,8 +1634,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>GHAC</rdfs:label>
 		<dct:description>the FpML business center code for Accra, Ghana</dct:description>
-		<fibo-fnd-rel-rel:hasTag>GHAC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>GHAC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Accra"/>
 	</owl:NamedIndividual>
 	
@@ -1642,8 +1643,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>GMBA</rdfs:label>
 		<dct:description>the FpML business center code for Banjul, Gambia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>GMBA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>GMBA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Banjul"/>
 	</owl:NamedIndividual>
 	
@@ -1651,8 +1652,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>GNCO</rdfs:label>
 		<dct:description>the FpML business center code for Conakry, Guinea</dct:description>
-		<fibo-fnd-rel-rel:hasTag>GNCO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>GNCO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Conakry"/>
 	</owl:NamedIndividual>
 	
@@ -1660,8 +1661,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>GRAT</rdfs:label>
 		<dct:description>the FpML business center code for Athens, Greece</dct:description>
-		<fibo-fnd-rel-rel:hasTag>GRAT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>GRAT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Athens"/>
 	</owl:NamedIndividual>
 	
@@ -1669,8 +1670,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>GUGC</rdfs:label>
 		<dct:description>the FpML business center code for Guatemala City, Guatemala</dct:description>
-		<fibo-fnd-rel-rel:hasTag>GUGC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>GUGC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Guatemala_City"/>
 	</owl:NamedIndividual>
 	
@@ -1785,8 +1786,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>HKHK</rdfs:label>
 		<dct:description>the FpML business center code for Hong Kong, Hong Kong</dct:description>
-		<fibo-fnd-rel-rel:hasTag>HKHK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>HKHK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Hong_Kong"/>
 	</owl:NamedIndividual>
 	
@@ -1794,8 +1795,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>HNTE</rdfs:label>
 		<dct:description>the FpML business center code for Tegucigalpa, Honduras</dct:description>
-		<fibo-fnd-rel-rel:hasTag>HNTE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>HNTE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Tegucigalpa"/>
 	</owl:NamedIndividual>
 	
@@ -1803,8 +1804,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>HRZA</rdfs:label>
 		<dct:description>the FpML business center code for Zagreb, Republic of Croatia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>HRZA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>HRZA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Zagreb"/>
 	</owl:NamedIndividual>
 	
@@ -1812,8 +1813,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>HUBU</rdfs:label>
 		<dct:description>the FpML business center code for Budapest, Hungary</dct:description>
-		<fibo-fnd-rel-rel:hasTag>HUBU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>HUBU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Budapest"/>
 	</owl:NamedIndividual>
 	
@@ -1928,8 +1929,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>IDJA</rdfs:label>
 		<dct:description>the FpML business center code for Jakarta, Indonesia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>IDJA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>IDJA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Jakarta"/>
 	</owl:NamedIndividual>
 	
@@ -1937,8 +1938,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>IEDU</rdfs:label>
 		<dct:description>the FpML business center code for Dublin, Ireland</dct:description>
-		<fibo-fnd-rel-rel:hasTag>IEDU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>IEDU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Dublin"/>
 	</owl:NamedIndividual>
 	
@@ -1946,8 +1947,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ILJE</rdfs:label>
 		<dct:description>the FpML business center code for Jerusalem, Israel</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ILJE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ILJE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Jerusalem"/>
 	</owl:NamedIndividual>
 	
@@ -1955,8 +1956,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ILTA</rdfs:label>
 		<dct:description>the FpML business center code for Tel Aviv, Israel</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ILTA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ILTA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Tel_Aviv"/>
 	</owl:NamedIndividual>
 	
@@ -1964,8 +1965,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>INAH</rdfs:label>
 		<dct:description>the FpML business center code for Ahmedabad, India</dct:description>
-		<fibo-fnd-rel-rel:hasTag>INAH</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>INAH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Ahmedabad"/>
 	</owl:NamedIndividual>
 	
@@ -1973,8 +1974,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>INBA</rdfs:label>
 		<dct:description>the FpML business center code for Bangalore, India</dct:description>
-		<fibo-fnd-rel-rel:hasTag>INBA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>INBA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Bangalore"/>
 	</owl:NamedIndividual>
 	
@@ -1982,8 +1983,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>INCH</rdfs:label>
 		<dct:description>the FpML business center code for Chennai, India</dct:description>
-		<fibo-fnd-rel-rel:hasTag>INCH</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>INCH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Chennai"/>
 	</owl:NamedIndividual>
 	
@@ -1991,8 +1992,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>INHY</rdfs:label>
 		<dct:description>the FpML business center code for Hyderabad, India</dct:description>
-		<fibo-fnd-rel-rel:hasTag>INHY</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>INHY</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Hyderabad"/>
 	</owl:NamedIndividual>
 	
@@ -2000,8 +2001,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>INKO</rdfs:label>
 		<dct:description>the FpML business center code for Kolkata, India</dct:description>
-		<fibo-fnd-rel-rel:hasTag>INKO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>INKO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Kolkata"/>
 	</owl:NamedIndividual>
 	
@@ -2009,8 +2010,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>INMU</rdfs:label>
 		<dct:description>the FpML business center code for Mumbai, India</dct:description>
-		<fibo-fnd-rel-rel:hasTag>INMU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>INMU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Mumbai"/>
 	</owl:NamedIndividual>
 	
@@ -2018,8 +2019,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>INND</rdfs:label>
 		<dct:description>the FpML business center code for New Delhi, India</dct:description>
-		<fibo-fnd-rel-rel:hasTag>INND</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>INND</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;New_Delhi"/>
 	</owl:NamedIndividual>
 	
@@ -2027,8 +2028,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>IQBA</rdfs:label>
 		<dct:description>the FpML business center code for Baghdad, Iraq</dct:description>
-		<fibo-fnd-rel-rel:hasTag>IQBA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>IQBA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Baghdad"/>
 	</owl:NamedIndividual>
 	
@@ -2036,8 +2037,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>IRTE</rdfs:label>
 		<dct:description>the FpML business center code for Teheran, Iran</dct:description>
-		<fibo-fnd-rel-rel:hasTag>IRTE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>IRTE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Teheran"/>
 	</owl:NamedIndividual>
 	
@@ -2045,8 +2046,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ISRE</rdfs:label>
 		<dct:description>the FpML business center code for Reykjavik, Iceland</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ISRE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ISRE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Reykjavik"/>
 	</owl:NamedIndividual>
 	
@@ -2054,8 +2055,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ITMI</rdfs:label>
 		<dct:description>the FpML business center code for Milan, Italy</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ITMI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ITMI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Milan"/>
 	</owl:NamedIndividual>
 	
@@ -2063,8 +2064,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ITRO</rdfs:label>
 		<dct:description>the FpML business center code for Rome, Italy</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ITRO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ITRO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Rome"/>
 	</owl:NamedIndividual>
 	
@@ -2072,8 +2073,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ITTU</rdfs:label>
 		<dct:description>the FpML business center code for Turin, Italy</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ITTU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ITTU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Turin"/>
 	</owl:NamedIndividual>
 	
@@ -2106,8 +2107,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>JESH</rdfs:label>
 		<dct:description>the FpML business center code for St. Helier, Channel Islands, Jersey</dct:description>
-		<fibo-fnd-rel-rel:hasTag>JESH</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>JESH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;St._Helier"/>
 	</owl:NamedIndividual>
 	
@@ -2115,8 +2116,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>JMKI</rdfs:label>
 		<dct:description>the FpML business center code for Kingston, Jamaica</dct:description>
-		<fibo-fnd-rel-rel:hasTag>JMKI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>JMKI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Kingston"/>
 	</owl:NamedIndividual>
 	
@@ -2124,8 +2125,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>JOAM</rdfs:label>
 		<dct:description>the FpML business center code for Amman, Jordan</dct:description>
-		<fibo-fnd-rel-rel:hasTag>JOAM</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>JOAM</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Amman"/>
 	</owl:NamedIndividual>
 	
@@ -2133,8 +2134,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>JPTO</rdfs:label>
 		<dct:description>the FpML business center code for Tokyo, Japan</dct:description>
-		<fibo-fnd-rel-rel:hasTag>JPTO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>JPTO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Tokyo"/>
 	</owl:NamedIndividual>
 	
@@ -2182,8 +2183,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>KENA</rdfs:label>
 		<dct:description>the FpML business center code for Nairobi, Kenya</dct:description>
-		<fibo-fnd-rel-rel:hasTag>KENA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>KENA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Nairobi"/>
 	</owl:NamedIndividual>
 	
@@ -2191,8 +2192,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>KHPP</rdfs:label>
 		<dct:description>the FpML business center code for Phnom Penh, Cambodia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>KHPP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>KHPP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Phnom_Penh"/>
 	</owl:NamedIndividual>
 	
@@ -2200,8 +2201,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>KRSE</rdfs:label>
 		<dct:description>the FpML business center code for Seoul, Republic of Korea</dct:description>
-		<fibo-fnd-rel-rel:hasTag>KRSE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>KRSE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Seoul"/>
 	</owl:NamedIndividual>
 	
@@ -2209,8 +2210,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>KWKC</rdfs:label>
 		<dct:description>the FpML business center code for Kuwait City, Kuwait</dct:description>
-		<fibo-fnd-rel-rel:hasTag>KWKC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>KWKC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Kuwait_City"/>
 	</owl:NamedIndividual>
 	
@@ -2218,8 +2219,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>KYGE</rdfs:label>
 		<dct:description>the FpML business center code for George Town, Cayman Islands</dct:description>
-		<fibo-fnd-rel-rel:hasTag>KYGE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>KYGE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;George_Town"/>
 	</owl:NamedIndividual>
 	
@@ -2227,8 +2228,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>KZAL</rdfs:label>
 		<dct:description>the FpML business center code for Almaty, Kazakhstan</dct:description>
-		<fibo-fnd-rel-rel:hasTag>KZAL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>KZAL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Almaty"/>
 	</owl:NamedIndividual>
 	
@@ -2364,8 +2365,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>LAVI</rdfs:label>
 		<dct:description>the FpML business center code for Vientiane, Laos</dct:description>
-		<fibo-fnd-rel-rel:hasTag>LAVI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>LAVI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Vientiane"/>
 	</owl:NamedIndividual>
 	
@@ -2373,8 +2374,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>LBBE</rdfs:label>
 		<dct:description>the FpML business center code for Beirut, Lebanon</dct:description>
-		<fibo-fnd-rel-rel:hasTag>LBBE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>LBBE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Beirut"/>
 	</owl:NamedIndividual>
 	
@@ -2382,8 +2383,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>LKCO</rdfs:label>
 		<dct:description>the FpML business center code for Colombo, Sri Lanka</dct:description>
-		<fibo-fnd-rel-rel:hasTag>LKCO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>LKCO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Colombo"/>
 	</owl:NamedIndividual>
 	
@@ -2391,8 +2392,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>LULU</rdfs:label>
 		<dct:description>the FpML business center code for Luxembourg, Luxembourg</dct:description>
-		<fibo-fnd-rel-rel:hasTag>LULU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>LULU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Luxembourg"/>
 	</owl:NamedIndividual>
 	
@@ -2400,8 +2401,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>LVRI</rdfs:label>
 		<dct:description>the FpML business center code for Riga, Latvia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>LVRI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>LVRI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Riga"/>
 	</owl:NamedIndividual>
 	
@@ -2560,8 +2561,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MACA</rdfs:label>
 		<dct:description>the FpML business center code for Casablanca, Morocco</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MACA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MACA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Casablanca"/>
 	</owl:NamedIndividual>
 	
@@ -2569,8 +2570,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MARA</rdfs:label>
 		<dct:description>the FpML business center code for Rabat, Morocco</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MARA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MARA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Rabat"/>
 	</owl:NamedIndividual>
 	
@@ -2578,8 +2579,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MCMO</rdfs:label>
 		<dct:description>the FpML business center code for Monaco, Monaco</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MCMO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MCMO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Monaco"/>
 	</owl:NamedIndividual>
 	
@@ -2587,8 +2588,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MNUB</rdfs:label>
 		<dct:description>the FpML business center code for Ulan Bator, Mongolia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MNUB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MNUB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Ulan_Bator"/>
 	</owl:NamedIndividual>
 	
@@ -2596,8 +2597,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MOMA</rdfs:label>
 		<dct:description>the FpML business center code for Macau, Macao</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MOMA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MOMA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Macau"/>
 	</owl:NamedIndividual>
 	
@@ -2605,8 +2606,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MTVA</rdfs:label>
 		<dct:description>the FpML business center code for Valletta, Malta</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MTVA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MTVA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Valletta"/>
 	</owl:NamedIndividual>
 	
@@ -2614,8 +2615,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MUPL</rdfs:label>
 		<dct:description>the FpML business center code for Port Louis, Mauritius</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MUPL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MUPL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Port_Louis"/>
 	</owl:NamedIndividual>
 	
@@ -2623,8 +2624,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MVMA</rdfs:label>
 		<dct:description>the FpML business center code for Male, Maldives</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MVMA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MVMA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Male"/>
 	</owl:NamedIndividual>
 	
@@ -2632,8 +2633,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MWLI</rdfs:label>
 		<dct:description>the FpML business center code for Lilongwe, Malawi</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MWLI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MWLI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Lilongwe"/>
 	</owl:NamedIndividual>
 	
@@ -2641,8 +2642,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MXMC</rdfs:label>
 		<dct:description>the FpML business center code for Mexico City, Mexico</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MXMC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MXMC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Mexico_City"/>
 	</owl:NamedIndividual>
 	
@@ -2650,8 +2651,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MYKL</rdfs:label>
 		<dct:description>the FpML business center code for Kuala Lumpur, Malaysia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MYKL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MYKL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Kuala_Lumpur"/>
 	</owl:NamedIndividual>
 	
@@ -2659,8 +2660,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MYLA</rdfs:label>
 		<dct:description>the FpML business center code for Labuan, Malaysia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MYLA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MYLA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Labuan"/>
 	</owl:NamedIndividual>
 	
@@ -2668,8 +2669,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>MZMA</rdfs:label>
 		<dct:description>the FpML business center code for Maputo, Mozambique</dct:description>
-		<fibo-fnd-rel-rel:hasTag>MZMA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>MZMA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Maputo"/>
 	</owl:NamedIndividual>
 	
@@ -2890,8 +2891,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>NAWI</rdfs:label>
 		<dct:description>the FpML business center code for Windhoek, Namibia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NAWI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NAWI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Windhoek"/>
 	</owl:NamedIndividual>
 	
@@ -2899,8 +2900,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>NGAB</rdfs:label>
 		<dct:description>the FpML business center code for Abuja, Nigeria</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NGAB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NGAB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Abuja"/>
 	</owl:NamedIndividual>
 	
@@ -2908,8 +2909,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>NGLA</rdfs:label>
 		<dct:description>the FpML business center code for Lagos, Nigeria</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NGLA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NGLA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Lagos"/>
 	</owl:NamedIndividual>
 	
@@ -2917,8 +2918,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>NLAM</rdfs:label>
 		<dct:description>the FpML business center code for Amsterdam, Netherlands</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NLAM</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NLAM</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Amsterdam"/>
 	</owl:NamedIndividual>
 	
@@ -2926,8 +2927,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>NLRO</rdfs:label>
 		<dct:description>the FpML business center code for Rotterdam, Netherlands</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NLRO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NLRO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Rotterdam"/>
 	</owl:NamedIndividual>
 	
@@ -2935,8 +2936,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>NOOS</rdfs:label>
 		<dct:description>the FpML business center code for Oslo, Norway</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NOOS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NOOS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Oslo"/>
 	</owl:NamedIndividual>
 	
@@ -2944,8 +2945,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>NPKA</rdfs:label>
 		<dct:description>the FpML business center code for Kathmandu, Nepal</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NPKA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NPKA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Kathmandu"/>
 	</owl:NamedIndividual>
 	
@@ -2953,8 +2954,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessDayAdjustmentCode"/>
 		<rdfs:label>NYFD</rdfs:label>
 		<dct:description>the FpML business center code for New York Fed Business Day (as defined in 2006 ISDA Definitions Section 1.9 and 2000 ISDA Definitions Section 1.9)</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NYFD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NYFD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;NewYorkFederalReserveBusinessDay"/>
 	</owl:NamedIndividual>
 	
@@ -2962,8 +2963,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessDayAdjustmentCode"/>
 		<rdfs:label>NYSE</rdfs:label>
 		<dct:description>the FpML business center code for New York Stock Exchange Business Day (as defined in 2006 ISDA Definitions Section 1.10 and 2000 ISDA Definitions Section 1.10)</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NYSE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NYSE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;NewYorkStockExchangeBusinessDay"/>
 	</owl:NamedIndividual>
 	
@@ -2971,8 +2972,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>NZAU</rdfs:label>
 		<dct:description>the FpML business center code for Auckland, New Zealand</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NZAU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NZAU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Auckland"/>
 	</owl:NamedIndividual>
 	
@@ -2980,8 +2981,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>NZWE</rdfs:label>
 		<dct:description>the FpML business center code for Wellington, New Zealand</dct:description>
-		<fibo-fnd-rel-rel:hasTag>NZWE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>NZWE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Wellington"/>
 	</owl:NamedIndividual>
 	
@@ -3110,8 +3111,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>OMMU</rdfs:label>
 		<dct:description>the FpML business center code for Muscat, Oman</dct:description>
-		<fibo-fnd-rel-rel:hasTag>OMMU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>OMMU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Muscat"/>
 	</owl:NamedIndividual>
 	
@@ -3157,8 +3158,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>PAPC</rdfs:label>
 		<dct:description>the FpML business center code for Panama City, Panama</dct:description>
-		<fibo-fnd-rel-rel:hasTag>PAPC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>PAPC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Panama_City"/>
 	</owl:NamedIndividual>
 	
@@ -3166,8 +3167,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>PELI</rdfs:label>
 		<dct:description>the FpML business center code for Lima, Peru</dct:description>
-		<fibo-fnd-rel-rel:hasTag>PELI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>PELI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Lima"/>
 	</owl:NamedIndividual>
 	
@@ -3175,8 +3176,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>PHMA</rdfs:label>
 		<dct:description>the FpML business center code for Manila, Philippines</dct:description>
-		<fibo-fnd-rel-rel:hasTag>PHMA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>PHMA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Manila"/>
 	</owl:NamedIndividual>
 	
@@ -3184,8 +3185,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>PHMK</rdfs:label>
 		<dct:description>the FpML business center code for Makati, Philippines</dct:description>
-		<fibo-fnd-rel-rel:hasTag>PHMK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>PHMK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Makati"/>
 	</owl:NamedIndividual>
 	
@@ -3193,8 +3194,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>PKKA</rdfs:label>
 		<dct:description>the FpML business center code for Karachi, Pakistan</dct:description>
-		<fibo-fnd-rel-rel:hasTag>PKKA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>PKKA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Karachi"/>
 	</owl:NamedIndividual>
 	
@@ -3202,8 +3203,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>PLWA</rdfs:label>
 		<dct:description>the FpML business center code for Warsaw, Poland</dct:description>
-		<fibo-fnd-rel-rel:hasTag>PLWA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>PLWA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Warsaw"/>
 	</owl:NamedIndividual>
 	
@@ -3211,8 +3212,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>PRSJ</rdfs:label>
 		<dct:description>the FpML business center code for San Juan, Puerto Rico</dct:description>
-		<fibo-fnd-rel-rel:hasTag>PRSJ</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>PRSJ</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;San_Juan"/>
 	</owl:NamedIndividual>
 	
@@ -3220,8 +3221,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>PTLI</rdfs:label>
 		<dct:description>the FpML business center code for Lisbon, Portugal</dct:description>
-		<fibo-fnd-rel-rel:hasTag>PTLI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>PTLI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Lisbon"/>
 	</owl:NamedIndividual>
 	
@@ -3363,8 +3364,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>QADO</rdfs:label>
 		<dct:description>the FpML business center code for Doha, Qatar</dct:description>
-		<fibo-fnd-rel-rel:hasTag>QADO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>QADO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Doha"/>
 	</owl:NamedIndividual>
 	
@@ -3378,8 +3379,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ROBU</rdfs:label>
 		<dct:description>the FpML business center code for Bucharest, Romania</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ROBU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ROBU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Bucharest"/>
 	</owl:NamedIndividual>
 	
@@ -3387,8 +3388,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>RSBE</rdfs:label>
 		<dct:description>the FpML business center code for Belgrade, Serbia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>RSBE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>RSBE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Belgrade"/>
 	</owl:NamedIndividual>
 	
@@ -3396,8 +3397,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>RUMO</rdfs:label>
 		<dct:description>the FpML business center code for Moscow, Russian Federation</dct:description>
-		<fibo-fnd-rel-rel:hasTag>RUMO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>RUMO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Moscow"/>
 	</owl:NamedIndividual>
 	
@@ -3509,8 +3510,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>SAAB</rdfs:label>
 		<dct:description>the FpML business center code for Abha, Saudi Arabia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>SAAB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>SAAB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Abha"/>
 	</owl:NamedIndividual>
 	
@@ -3518,8 +3519,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>SAJE</rdfs:label>
 		<dct:description>the FpML business center code for Jeddah, Saudi Arabia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>SAJE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>SAJE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Jeddah"/>
 	</owl:NamedIndividual>
 	
@@ -3527,8 +3528,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>SARI</rdfs:label>
 		<dct:description>the FpML business center code for Riyadh, Saudi Arabia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>SARI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>SARI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Riyadh"/>
 	</owl:NamedIndividual>
 	
@@ -3536,8 +3537,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>SEST</rdfs:label>
 		<dct:description>the FpML business center code for Stockholm, Sweden</dct:description>
-		<fibo-fnd-rel-rel:hasTag>SEST</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>SEST</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Stockholm"/>
 	</owl:NamedIndividual>
 	
@@ -3545,8 +3546,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>SGSI</rdfs:label>
 		<dct:description>the FpML business center code for Singapore, Singapore</dct:description>
-		<fibo-fnd-rel-rel:hasTag>SGSI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>SGSI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Singapore"/>
 	</owl:NamedIndividual>
 	
@@ -3554,8 +3555,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>SILJ</rdfs:label>
 		<dct:description>the FpML business center code for Ljubljana, Slovenia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>SILJ</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>SILJ</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Ljubljana"/>
 	</owl:NamedIndividual>
 	
@@ -3563,8 +3564,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>SKBR</rdfs:label>
 		<dct:description>the FpML business center code for Bratislava, Slovakia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>SKBR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>SKBR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Bratislava"/>
 	</owl:NamedIndividual>
 	
@@ -3572,8 +3573,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>SLFR</rdfs:label>
 		<dct:description>the FpML business center code for Freetown, Sierra Leone</dct:description>
-		<fibo-fnd-rel-rel:hasTag>SLFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>SLFR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Freetown"/>
 	</owl:NamedIndividual>
 	
@@ -3581,8 +3582,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>SNDA</rdfs:label>
 		<dct:description>the FpML business center code for Dakar, Senegal</dct:description>
-		<fibo-fnd-rel-rel:hasTag>SNDA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>SNDA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Dakar"/>
 	</owl:NamedIndividual>
 	
@@ -3590,8 +3591,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>SVSS</rdfs:label>
 		<dct:description>the FpML business center code for San Salvador, El Salvador</dct:description>
-		<fibo-fnd-rel-rel:hasTag>SVSS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>SVSS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;San_Salvador"/>
 	</owl:NamedIndividual>
 	
@@ -3907,8 +3908,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>THBA</rdfs:label>
 		<dct:description>the FpML business center code for Bangkok, Thailand</dct:description>
-		<fibo-fnd-rel-rel:hasTag>THBA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>THBA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Bangkok"/>
 	</owl:NamedIndividual>
 	
@@ -3916,8 +3917,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>TNTU</rdfs:label>
 		<dct:description>the FpML business center code for Tunis, Tunisia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>TNTU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>TNTU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Tunis"/>
 	</owl:NamedIndividual>
 	
@@ -3925,8 +3926,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>TRAN</rdfs:label>
 		<dct:description>the FpML business center code for Ankara, Turkey</dct:description>
-		<fibo-fnd-rel-rel:hasTag>TRAN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>TRAN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Ankara"/>
 	</owl:NamedIndividual>
 	
@@ -3934,8 +3935,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>TRIS</rdfs:label>
 		<dct:description>the FpML business center code for Istanbul, Turkey</dct:description>
-		<fibo-fnd-rel-rel:hasTag>TRIS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>TRIS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Istanbul"/>
 	</owl:NamedIndividual>
 	
@@ -3943,8 +3944,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>TTPS</rdfs:label>
 		<dct:description>the FpML business center code for Port of Spain, Trinidad and Tobago</dct:description>
-		<fibo-fnd-rel-rel:hasTag>TTPS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>TTPS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Port_of_Spain"/>
 	</owl:NamedIndividual>
 	
@@ -3952,8 +3953,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>TWTA</rdfs:label>
 		<dct:description>the FpML business center code for Taipei, Taiwan</dct:description>
-		<fibo-fnd-rel-rel:hasTag>TWTA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>TWTA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Taipei"/>
 	</owl:NamedIndividual>
 	
@@ -3961,8 +3962,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>TZDA</rdfs:label>
 		<dct:description>the FpML business center code for Dar es Salaam, Tanzania</dct:description>
-		<fibo-fnd-rel-rel:hasTag>TZDA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>TZDA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Dar_es_Salaam"/>
 	</owl:NamedIndividual>
 	
@@ -3970,8 +3971,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>TZDO</rdfs:label>
 		<dct:description>the FpML business center code for Dodoma, Tanzania</dct:description>
-		<fibo-fnd-rel-rel:hasTag>TZDO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>TZDO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Dodoma"/>
 	</owl:NamedIndividual>
 	
@@ -4122,8 +4123,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>UAKI</rdfs:label>
 		<dct:description>the FpML business center code for Kiev, Ukraine</dct:description>
-		<fibo-fnd-rel-rel:hasTag>UAKI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>UAKI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Kiev"/>
 	</owl:NamedIndividual>
 	
@@ -4131,8 +4132,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>UGKA</rdfs:label>
 		<dct:description>the FpML business center code for Kampala, Uganda</dct:description>
-		<fibo-fnd-rel-rel:hasTag>UGKA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>UGKA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Kampala"/>
 	</owl:NamedIndividual>
 	
@@ -4140,8 +4141,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USBO</rdfs:label>
 		<dct:description>the FpML business center code for Boston, Massachusetts, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USBO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USBO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Boston"/>
 	</owl:NamedIndividual>
 	
@@ -4149,8 +4150,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USCH</rdfs:label>
 		<dct:description>the FpML business center code for Chicago, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USCH</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USCH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Chicago"/>
 	</owl:NamedIndividual>
 	
@@ -4158,8 +4159,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USCR</rdfs:label>
 		<dct:description>the FpML business center code for Charlotte, North Carolina, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USCR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USCR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Charlotte"/>
 	</owl:NamedIndividual>
 	
@@ -4167,8 +4168,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USDC</rdfs:label>
 		<dct:description>the FpML business center code for Washington, District of Columbia, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USDC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USDC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Washington"/>
 	</owl:NamedIndividual>
 	
@@ -4176,8 +4177,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USDN</rdfs:label>
 		<dct:description>the FpML business center code for Denver, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USDN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USDN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Denver"/>
 	</owl:NamedIndividual>
 	
@@ -4185,8 +4186,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USDT</rdfs:label>
 		<dct:description>the FpML business center code for Detroit, Michigan, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USDT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USDT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Detroit"/>
 	</owl:NamedIndividual>
 	
@@ -4194,8 +4195,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessDayAdjustmentCode"/>
 		<rdfs:label>USGS</rdfs:label>
 		<dct:description>the FpML business center code for U.S. Government Securities Business Day (as defined in 2006 ISDA Definitions Section 1.11 and 2000 ISDA Definitions Section 1.11)</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USGS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USGS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;USGovernmentSecuritiesBusinessDay"/>
 	</owl:NamedIndividual>
 	
@@ -4210,8 +4211,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USHL</rdfs:label>
 		<dct:description>the FpML business center code for Honolulu, Hawaii, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USHL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USHL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Honolulu"/>
 	</owl:NamedIndividual>
 	
@@ -4219,8 +4220,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USHO</rdfs:label>
 		<dct:description>the FpML business center code for Houston, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USHO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USHO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Houston"/>
 	</owl:NamedIndividual>
 	
@@ -4228,8 +4229,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USLA</rdfs:label>
 		<dct:description>the FpML business center code for Los Angeles, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USLA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USLA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Los_Angeles"/>
 	</owl:NamedIndividual>
 	
@@ -4237,8 +4238,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USMB</rdfs:label>
 		<dct:description>the FpML business center code for Mobile, Alabama, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USMB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USMB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Mobile"/>
 	</owl:NamedIndividual>
 	
@@ -4246,8 +4247,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USMN</rdfs:label>
 		<dct:description>the FpML business center code for Minneapolis, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USMN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USMN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Minneapolis"/>
 	</owl:NamedIndividual>
 	
@@ -4255,8 +4256,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USNY</rdfs:label>
 		<dct:description>the FpML business center code for New York, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USNY</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USNY</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;New_York"/>
 	</owl:NamedIndividual>
 	
@@ -4264,8 +4265,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USPO</rdfs:label>
 		<dct:description>the FpML business center code for Portland, Oregon, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USPO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USPO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Portland"/>
 	</owl:NamedIndividual>
 	
@@ -4273,8 +4274,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USSA</rdfs:label>
 		<dct:description>the FpML business center code for Sacramento, California, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USSA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USSA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Sacramento"/>
 	</owl:NamedIndividual>
 	
@@ -4282,8 +4283,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USSE</rdfs:label>
 		<dct:description>the FpML business center code for Seattle, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USSE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USSE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Seattle"/>
 	</owl:NamedIndividual>
 	
@@ -4291,8 +4292,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USSF</rdfs:label>
 		<dct:description>the FpML business center code for San Francisco, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USSF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USSF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;San_Francisco"/>
 	</owl:NamedIndividual>
 	
@@ -4300,8 +4301,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>USWT</rdfs:label>
 		<dct:description>the FpML business center code for Wichita, United States</dct:description>
-		<fibo-fnd-rel-rel:hasTag>USWT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>USWT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Wichita"/>
 	</owl:NamedIndividual>
 	
@@ -4309,8 +4310,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>UYMO</rdfs:label>
 		<dct:description>the FpML business center code for Montevideo, Uruguay</dct:description>
-		<fibo-fnd-rel-rel:hasTag>UYMO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>UYMO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Montevideo"/>
 	</owl:NamedIndividual>
 	
@@ -4318,8 +4319,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>UZTA</rdfs:label>
 		<dct:description>the FpML business center code for Tashkent, Uzbekistan</dct:description>
-		<fibo-fnd-rel-rel:hasTag>UZTA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>UZTA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Tashkent"/>
 	</owl:NamedIndividual>
 	
@@ -4346,8 +4347,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>VECA</rdfs:label>
 		<dct:description>the FpML business center code for Caracas, Venezuela</dct:description>
-		<fibo-fnd-rel-rel:hasTag>VECA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>VECA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Caracas"/>
 	</owl:NamedIndividual>
 	
@@ -4355,8 +4356,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>VGRT</rdfs:label>
 		<dct:description>the FpML business center code for Road Town, Virgin Islands (British)</dct:description>
-		<fibo-fnd-rel-rel:hasTag>VGRT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>VGRT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Road_Town"/>
 	</owl:NamedIndividual>
 	
@@ -4364,8 +4365,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>VNHA</rdfs:label>
 		<dct:description>the FpML business center code for Hanoi, Vietnam</dct:description>
-		<fibo-fnd-rel-rel:hasTag>VNHA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>VNHA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Hanoi"/>
 	</owl:NamedIndividual>
 	
@@ -4373,8 +4374,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>VNHC</rdfs:label>
 		<dct:description>the FpML business center code for Ho Chi Minh (formerly Saigon), Vietnam</dct:description>
-		<fibo-fnd-rel-rel:hasTag>VNHC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>VNHC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Ho_Chi_Minh__formerly_Saigon_"/>
 	</owl:NamedIndividual>
 	
@@ -4537,8 +4538,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>YEAD</rdfs:label>
 		<dct:description>the FpML business center code for Aden, Yemen</dct:description>
-		<fibo-fnd-rel-rel:hasTag>YEAD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>YEAD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Aden"/>
 	</owl:NamedIndividual>
 	
@@ -4560,8 +4561,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ZAJO</rdfs:label>
 		<dct:description>the FpML business center code for Johannesburg, South Africa</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ZAJO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ZAJO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Johannesburg"/>
 	</owl:NamedIndividual>
 	
@@ -4569,8 +4570,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ZMLU</rdfs:label>
 		<dct:description>the FpML business center code for Lusaka, Zambia</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ZMLU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ZMLU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Lusaka"/>
 	</owl:NamedIndividual>
 	
@@ -4578,8 +4579,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-bc;BusinessCenterCode"/>
 		<rdfs:label>ZWHA</rdfs:label>
 		<dct:description>the FpML business center code for Harare, Zimbabwe</dct:description>
-		<fibo-fnd-rel-rel:hasTag>ZWHA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fbc-fct-bci;FpMLBusinessCenterCodeScheme"/>
+		<cmns-dsg:hasTag>ZWHA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-bci;Harare"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/BusinessRegistries.rdf
+++ b/FBC/FunctionalEntities/BusinessRegistries.rdf
@@ -92,7 +92,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260601/FunctionalEntities/BusinessRegistries/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260701/FunctionalEntities/BusinessRegistries/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.1 RTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified per FIBO 2.0 RFC primarily to loosen the constraints on address properties and better support standards including ISO 9362 (BIC codes), ISO 13616 (IBAN and BBAN codes), and ISO 17442 (the GLIEF LEI standard).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified to generalize certain unions where they were no longer required, use the composite date datatype where appropriate, add individuals for entity expiration reason and validation level to better align with the GLEIF LEI data, and move international registration authorities, such as SWIFT, to a separate ontology for better modularity.</skos:changeNote>
@@ -112,6 +112,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/BusinessRegistries.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/BusinessRegistries.rdf version of the ontology was modified to merge details from the old corporations ontology into corporate bodies for consistency and useability (BE-259).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251201/FunctionalEntities/BusinessRegistries.rdf version of the ontology was modified to augment details related to GLEIF LEI records as needed to extend examples (FND-407).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20260601/FunctionalEntities/BusinessRegistries.rdf version of the ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2020-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2020-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -129,16 +130,16 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityStatus"/>
 		<rdfs:label>active status</rdfs:label>
 		<skos:definition>status indicating that as of the last report or update, the entity was legally registered and operating</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ACTIVE</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>ACTIVE</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;AnnulledStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>annulled status</rdfs:label>
 		<skos:definition>status indicating that the registration was determined to be erroneous or invalid after issuance</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ANNULLED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>ANNULLED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;BusinessRegisterIdentifier">
@@ -238,23 +239,23 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>cancelled status</rdfs:label>
 		<skos:definition>status indicating that the registration was abandoned prior to issuance</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CANCELLED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>CANCELLED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;DuplicateStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>duplicate status</rdfs:label>
 		<skos:definition>status indicating that the registration was determined to be a duplicate registration of the same entity as another registration; duplicate status is assigned to the non-surviving registration (i.e. the identifier that should no longer be used)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DUPLICATE</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>DUPLICATE</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;EntityExpirationReason">
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -268,24 +269,24 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
 		<rdfs:label>entity expiration reason - corporate action</rdfs:label>
 		<skos:definition>expiration reason indicating that an entity was acquired or merged with another entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CORPORATE_ACTION</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>CORPORATE_ACTION</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;EntityExpirationReasonDissolved">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
 		<rdfs:label>entity expiration reason - disolved</rdfs:label>
 		<skos:definition>expiration reason indicating that an entity ceased to operate</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DISSOLVED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>DISSOLVED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;EntityExpirationReasonOther">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
 		<rdfs:label>entity expiration reason - other</rdfs:label>
 		<skos:definition>expiration reason indicating something that is neither due to disolution nor corporate action</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>OTHER</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>OTHER</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;EntityLegalFormRegistry">
@@ -328,7 +329,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -342,48 +343,48 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevel"/>
 		<rdfs:label>entity validation level - entity-supplied only</rdfs:label>
 		<skos:definition>Based on the validation procedures in use by the LOU responsible for the record, the information associated with this record has significant reliance on the information that a submitter provided due to the unavailability of corroborating information.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ENTITY_SUPPLIED_ONLY</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>ENTITY_SUPPLIED_ONLY</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevel"/>
 		<rdfs:label>entity validation level - fully corroborated</rdfs:label>
 		<skos:definition>Based on the validation procedures in use by the LOU responsible for the record, there is sufficient information contained in authoritative public sources to corroborate the information that the submitter has provided for the record.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>FULLY_CORROBORATED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>FULLY_CORROBORATED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;EntityValidationLevelPartiallyCorroborated">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevel"/>
 		<rdfs:label>entity validation level - partially corroborated</rdfs:label>
 		<skos:definition>Based on the validation procedures in use by the LOU responsible for the record, the information supplied by the registrant can be partially corroborated by public authoritative sources, while some of the record is dependent upon the information that the registrant submitted, either due to conflicts with authoritative information, or due to data unavailability.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PARTIALLY_CORROBORATED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>PARTIALLY_CORROBORATED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;InactiveStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityStatus"/>
 		<rdfs:label>inactive status</rdfs:label>
 		<skos:definition>status indicating that the entity is no longer legally registered and/or operating, whether as a result of business closure, acquisition by or merger with another (or new) entity, or determination of illegitimacy</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>INACTIVE</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>INACTIVE</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;IssuedStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>issued status</rdfs:label>
 		<skos:definition>status indicating that the registration has been validated and issued, and which identifies an entity that was operating legally as of the last update</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ISSUED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>ISSUED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;LapsedStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>lapsed status</rdfs:label>
 		<skos:definition>status indicating that the registration that has not been renewed by the specified renewal date and is not known by public sources to have ceased operation as of the last update</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>LAPSED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>LAPSED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistry">
@@ -464,8 +465,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>merged status</rdfs:label>
 		<skos:definition>status indicating that the registration is for an entity that has been merged into another legal entity, such that this legal entity no longer exists as an independently operating entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MERGED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>MERGED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;NorthAmericanIndustryClassificationSystemCode">
@@ -480,7 +481,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -517,24 +518,24 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>pending archival status</rdfs:label>
 		<skos:definition>status indicating that the registration is about to be transferred to a different registration authority, after which its registration status will revert to a non-pending status</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PENDING_ARCHIVAL</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>PENDING_ARCHIVAL</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;PendingTransferStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>pending transfer status</rdfs:label>
 		<skos:definition>status indicating that the registration has requested transfer to a different registration authority, and for which transfer is in progress</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PENDING_TRANSFER</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>PENDING_TRANSFER</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;PendingValidationStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>pending validation status</rdfs:label>
 		<skos:definition>status indicating that an application for registration has been submitted and is in process, pending validation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PENDING_VALIDATION</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>PENDING_VALIDATION</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;RegistrationAuthorityCode">
@@ -564,8 +565,8 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>retired status</rdfs:label>
 		<skos:definition>status indicating that the registration is for an entity that has ceased operation, without having been merged into another entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RETIRED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>RETIRED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;StandardIndustrialClassificationCode">
@@ -580,7 +581,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -615,8 +616,8 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>transferred status</rdfs:label>
 		<skos:definition>status indicating that the registration that has been transferred to a different registration authority</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TRANSFERRED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>TRANSFERRED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasAlternativeLanguageLegalName">

--- a/FBC/FunctionalEntities/CommercialRegistrationAuthorities.rdf
+++ b/FBC/FunctionalEntities/CommercialRegistrationAuthorities.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
@@ -43,6 +44,7 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
@@ -124,7 +126,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260601/FunctionalEntities/CommercialRegistrationAuthorities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260701/FunctionalEntities/CommercialRegistrationAuthorities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to normalize a few labels and definitions, revise GLEIF LEI registration data, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
@@ -139,6 +141,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of the ontology was modified to refine and streamline the definitions of some service providers (SEC-205).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251001/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of the ontology was modified to merge details from the old corporations ontology into corporate bodies for consistency and useability (BE-259).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251002/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of the ontology was renamed to improve clarity, moved from the North American jurisdiction-level to the Functional Entities module, augmented with additional international organizations, and better aligned with the GLEIF LEI repository for broader FIBO usage (FND-407).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20260601/FunctionalEntities/FunctionalEntities/CommercialRegistrationAuthorities.rdf version of the ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2017-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2017-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -148,7 +151,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>London Stock Exchange plc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for London Stock Exchange plc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>213800D1EI4B9WTWWD28</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>213800D1EI4B9WTWWD28</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;LondonStockExchangePlc"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;LondonStockExchangeAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -171,7 +174,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>LuxCSD S.A. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for LuxCSD S.A.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>222100T6ICDIY8V4VX70</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>222100T6ICDIY8V4VX70</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;LuxCSDSA"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;LuxCSDAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -194,7 +197,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>SIX Financial Information AG legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for SIX Financial Information AG</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>506700D369548LQDC335</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>506700D369548LQDC335</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;SIXFinancialInformationAG"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmann"/>
 	</owl:NamedIndividual>
@@ -217,7 +220,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann GmbH &amp; Co. KG legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann GmbH &amp; Co. KG</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5299000J2N45DDNE4Y28</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5299000J2N45DDNE4Y28</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmannGmbHAndCoKG-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmann"/>
 	</owl:NamedIndividual>
@@ -240,7 +243,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Ubisecure Oy legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Ubisecure Oy</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>529900T8BM49AURSDO55</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>529900T8BM49AURSDO55</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;UBIsecureOy-FI"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;UbisecureAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -263,7 +266,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>SIX Group AG legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for SIX Group AG</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>529900ZMNQFCPP762W05</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>529900ZMNQFCPP762W05</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;SIXGroupAG"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmann"/>
 	</owl:NamedIndividual>
@@ -286,7 +289,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Intercontinental Exchange legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Intercontinental Exchange</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5493000F4ZO33MV32P92</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5493000F4ZO33MV32P92</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;IntercontinentalExchangeInc-US-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -309,7 +312,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Bloomberg Finance LP legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Bloomberg Finance LP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5493001KJTIIGC8Y1R12</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5493001KJTIIGC8Y1R12</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLP-US-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -332,7 +335,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Thomson Reuters Corporation legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Thomson Reuters Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300561UZND4C7B569</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300561UZND4C7B569</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;ThomsonReutersCorporation"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -355,7 +358,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>BSDR LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for BSDR LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5493006SPIZKPPCPBB70</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5493006SPIZKPPCPBB70</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;BSDRLLC-US-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -378,7 +381,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Bloomberg L.P. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Bloomberg L.P.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300B56MD0ZC402L06</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300B56MD0ZC402L06</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;BloombergLP-US-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -401,7 +404,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Euroclear SA/NV legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Euroclear SA/NV</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300CBNW05DILT6870</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300CBNW05DILT6870</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;EuroclearSANV"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BusinessEntityData"/>
 	</owl:NamedIndividual>
@@ -424,7 +427,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>DTCC Data Repository (U.S) LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for DTCC Data Repository (U.S) LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300H9ZM7RDBM87W85</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300H9ZM7RDBM87W85</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;DTCCDataRepositoryLLC-US-NY"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -447,7 +450,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>The Depository Trust Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Depository Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MLDY5N6PZ58ZE60QU102</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>MLDY5N6PZ58ZE60QU102</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;DTC-US-NY"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -470,7 +473,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>ICE Trade Vault, LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for ICE Trade Vault, LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300KE78SX8RVDNO58</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300KE78SX8RVDNO58</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;ICETradeVaultLLC-US-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -493,7 +496,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Clearstream Banking S.A. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Clearstream Banking S.A.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300OL514RA0SXJJ44</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300OL514RA0SXJJ44</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;ClearstreamBankingSA"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;LuxCSDAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -516,7 +519,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Business Entity Data (BED) B.V. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Business Entity Data (BED) B.V.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>EVK05KS7XY1DEII3R011</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>EVK05KS7XY1DEII3R011</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;BusinessEntityData-NL"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BusinessEntityData"/>
 	</owl:NamedIndividual>
@@ -539,7 +542,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>The Depository Trust &amp; Clearing Corporation legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Depository Trust &amp; Clearing Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MLDY5N6PZ58ZE60QU102</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>MLDY5N6PZ58ZE60QU102</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;DTCC-US-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -562,7 +565,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Chicago Mercantile Exchange, Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Chicago Mercantile Exchange, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SNZ2OJLFK8MNNCLQOF39</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>SNZ2OJLFK8MNNCLQOF39</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;ChicagoMercantileExchangeInc-US-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -585,7 +588,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>BGC Partners, Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for BGC Partners, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TF1LXM1YNB81WKUH5G19</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>TF1LXM1YNB81WKUH5G19</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;BGCPartnersInc-US-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -608,7 +611,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>S&amp;P Global, Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for S&amp;P Global, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>Y6X4K52KMJMZE7I7MY94</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>Y6X4K52KMJMZE7I7MY94</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;SPGlobalInc-US-NY"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -641,7 +644,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>BGC Partners, Inc. business entity identifier</rdfs:label>
 		<skos:definition>Delaware Division of Corporations business entity identifier for BGC Partners, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3051512</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3051512</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;BGCPartnersInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -667,7 +670,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>BSDR LLC business entity identifier</rdfs:label>
 		<skos:definition>Delaware Division of Corporations business entity identifier for BSDR LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5202500</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5202500</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;BSDRLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -705,7 +708,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>Bloomberg L.P. business entity identifier</rdfs:label>
 		<skos:definition>Delaware Division of Corporations business entity identifier for Bloomberg L.P.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>2110234</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>2110234</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;BloombergLP-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -720,7 +723,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>Bloomberg Finance L.P. business entity identifier</rdfs:label>
 		<skos:definition>Delaware Division of Corporations business entity identifier for Bloomberg Finance L.P.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4348344</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4348344</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLP-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -844,7 +847,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>Chicago Mercantile Exchange (CME) business entity identifier</rdfs:label>
 		<skos:definition>Delaware Division of Corporations business entity identifier for Chicago Mercantile Exchange, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3151025</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3151025</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;ChicagoMercantileExchangeInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -951,7 +954,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>business entity identifier for DTCC Data Repository (U.S) LLC</rdfs:label>
 		<skos:definition>New York State Division of Corporations business entity identifier for DTCC Data Repository (U.S.) LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4156912</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4156912</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;DTCCDataRepositoryLLC-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -1170,7 +1173,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>business entity identifier for ICE Trade Vault, LLC</rdfs:label>
 		<skos:definition>Delaware Division of Corporations business entity identifier for ICE Trade Vault, LLC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4960384</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4960384</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;ICETradeVaultLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1205,7 +1208,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>Intercontinental Exchange, Inc. business entity identifier</rdfs:label>
 		<skos:definition>Delaware Division of Corporations business entity identifier for Intercontinental Exchange, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5298907</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5298907</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;IntercontinentalExchangeInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1419,7 +1422,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>S&amp;P Global Inc. business entity identifier</rdfs:label>
 		<skos:definition>New York Division of Corporations business entity identifier for S&amp;P Global Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>99979</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>99979</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;SPGlobalInc-US-NY"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
@@ -37,6 +38,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
@@ -94,6 +96,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
@@ -102,7 +105,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260601/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260701/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20230101/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
@@ -115,6 +118,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of the ontology was modified to eliminate potential circular imports and extend the set of regulatory agencies (SEC-215).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20260301/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of the ontology was modified to reflect migration of the US Financial Services Entities Individuals to Commercial Registration Authorities, and for better alignment with the GLEIF LEI repository for broader FIBO usage (FND-407).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20260601/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of the ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2017-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2017-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -124,7 +128,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>European Central Bank legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for the European Central Bank</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300DTUYXVMJXZNY75</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300DTUYXVMJXZNY75</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-eurga;EuropeanCentralBank"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmann"/>
 	</owl:NamedIndividual>

--- a/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf
+++ b/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
@@ -31,6 +32,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
@@ -60,9 +62,9 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/InternationalRegistriesAndAuthorities/">
 		<rdfs:label>International Registries and Authorities Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the Business Registries ontology to define commonly referenced international registration authorities and related registry details, where the multi-national responsibilities for registering and/or managing various identifiers needed in banking applications occur, such as SWIFT. These individuals and in some cases, such as registry entries, are managed independently to reduce the import footprint for applications that do not require them, in other words, to support modularity needs of FIBO users.</dct:abstract>
-		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
+		<dct:license>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2015-2025 Object Management Group, Inc.
-
+		
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
@@ -83,29 +85,31 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/InternationalRegistriesAndAuthorities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260701/FunctionalEntities/InternationalRegistriesAndAuthorities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf version of this ontology was revised to add details for the Global LEI Foundation and fix spelling errors.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20211201/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf version of this ontology was revised to address text formatting issues uncovered via hygiene testing.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20220801/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230101/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20230301/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/InternationalRegistriesAndAuthorities.rdf version of the ontology was modified to replace additional properties that are now available in the OMG Commons Ontology Library (Commons) v1.3 (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="https://rdf.gleif.org/L1/L-506700GE1G29325QX363-LEI">
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Global Legal Entity Identifier Foundation legal entity identifier</rdfs:label>
 		<skos:definition>identifier and link to the official legal entity identifier registry entry for the Global Legal Entity Identifier Foundation as published in the Global LEI Index</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>506700GE1G29325QX363</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>506700GE1G29325QX363</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-ireg;GlobalLegalEntityIdentifierFoundation"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-ireg;GlobalLEIIndex"/>
 	</owl:NamedIndividual>
@@ -114,7 +118,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Society for Worldwide Interbank Financial Telecommunication (SWIFT) legal entity identifier</rdfs:label>
 		<skos:definition>identifier and link to the official legal entity identifier registry entry for the Society for Worldwide Interbank Financial Telecommunication (SWIFT)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HB7FFAZI0OMZ8PP8OE26</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>HB7FFAZI0OMZ8PP8OE26</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-ireg;SocietyForWorldwideInterbankFinancialTelecommunication"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-ireg;GlobalLEIIndex"/>
 	</owl:NamedIndividual>
@@ -123,7 +127,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Bank for International Settlements legal entity identifier</rdfs:label>
 		<skos:definition>identifier and link to the official legal entity identifier registry entry for the Bank for International Settlements</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UXIATLMNPCXXT5KR1S08</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>UXIATLMNPCXXT5KR1S08</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-ireg;BankForInternationalSettlements"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-ireg;GlobalLEIIndex"/>
 	</owl:NamedIndividual>

--- a/FBC/FunctionalEntities/Markets.rdf
+++ b/FBC/FunctionalEntities/Markets.rdf
@@ -56,9 +56,9 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/">
 		<rdfs:label>Markets Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for markets, exchanges, regulated markets, and multilateral trading facilities.</dct:abstract>
-		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
+		<dct:license>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2015-2025 Object Management Group, Inc.
-		
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
@@ -84,7 +84,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/SitesAndFacilities/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20251201/FunctionalEntities/Markets/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260701/FunctionalEntities/Markets/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/Markets/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 RTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20170201/FunctionalEntities/Markets/ version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/Markets/ version of this ontology was modified to generalize certain unions where they were no longer required and to move international registration authorities individuals to a separate ontology for better modularity.</skos:changeNote>
@@ -101,18 +101,19 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20231101/FunctionalEntities/Markets.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20240101/FunctionalEntities/Markets.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/Markets.rdf version of the ontology was modified to reuse concepts from the Commons 1.3 sites and facilities ontology (FND-401).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251201/FunctionalEntities/Markets.rdf version of the ontology was modified to reflect migration of additional properties to Commons 1.3 (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;ActiveMICStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketIdentifierCodeStatus"/>
 		<rdfs:label>active MIC status</rdfs:label>
 		<skos:definition>market identifier code status that indicates that as of the last report or update, the code was registered and actively in use</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ACTIVE</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), version 2.0</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>ACTIVE</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;AlternativeTradingSystem">
@@ -395,9 +396,9 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketIdentifierCodeStatus"/>
 		<rdfs:label>expired MIC status</rdfs:label>
 		<skos:definition>as of the last report or update, the exchange code has expired</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>EXPIRED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, version 2.0</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>EXPIRED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;ISO10383-ClassificationScheme">
@@ -465,128 +466,128 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - APPA</rdfs:label>
 		<skos:definition>market category classifier for an approved publication arrangement</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>APPA</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>APPA</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-ARMS">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - ARMS</rdfs:label>
 		<skos:definition>market category classifier for an approved reporting mechanism</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ARMS</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>ARMS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-ATSS">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - ATSS</rdfs:label>
 		<skos:definition>market category classifier for an alternative trading system</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ATSS</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>ATSS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-CASP">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - CASP</rdfs:label>
 		<skos:definition>market category classifier for a crypto asset services provider</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CASP</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>CASP</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-CTPS">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - CTPS</rdfs:label>
 		<skos:definition>market category classifier for a consolidated tape provider</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CTPS</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>CTPS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-DCMS">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - DCMS</rdfs:label>
 		<skos:definition>market category classifier for a designated contract market</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DCMS</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>DCMS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-IDQS">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - IDQS</rdfs:label>
 		<skos:definition>market category classifier for an interdealer quotation system</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IDQS</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>IDQS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-MLTF">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - MLTF</rdfs:label>
 		<skos:definition>market category classifier for a multilateral trading facility</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MLTF</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>MLTF</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-NSPD">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - NSPD</rdfs:label>
 		<skos:definition>market category classifier indicating that the market category has not been specified by the reporting party</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NSPD</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>NSPD</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-OTFS">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - OTFS</rdfs:label>
 		<skos:definition>market category classifier for an organized trading facility</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>OTFS</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>OTFS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-OTHR">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - OTHR</rdfs:label>
 		<skos:definition>market category classifier indicating that the reporting party believes that the market classifier is something other than any of the given market categories</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>OTHR</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>OTHR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-RMKT">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - RMKT</rdfs:label>
 		<skos:definition>market category classifier for a regulated market</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RMKT</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>RMKT</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-RMOS">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - RMOS</rdfs:label>
 		<skos:definition>market category classifier for a recognized market operator</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RMOS</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>RMOS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-SEFS">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - SEFS</rdfs:label>
 		<skos:definition>market category classifier for a swap execution facility</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SEFS</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>SEFS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-SINT">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - SINT</rdfs:label>
 		<skos:definition>market category classifier for a systematic internalizer</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SINT</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>SINT</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketCategoryClassifier-TRFS">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketCategoryClassifier"/>
 		<rdfs:label>market category classifier - TRFS</rdfs:label>
 		<skos:definition>market category classifier for a trade reporting facility</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TRFS</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>TRFS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;MarketIdentifier">
@@ -666,16 +667,16 @@ The securities traded on a stock exchange include: shares issued by companies, u
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketLevelClassifier"/>
 		<rdfs:label>market-level classifier - OPRT</rdfs:label>
 		<skos:definition>market-level classifier for an operating-level facility</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>OPRT</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>OPRT</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-mkt;MarketLevelClassifier-SGMT">
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketLevelClassifier"/>
 		<rdfs:label>market-level classifier - SGMT</rdfs:label>
 		<skos:definition>market-level classifier for a segment-level facility</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SGMT</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>SGMT</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-mkt;MarketSegmentLevelMarket">
@@ -965,9 +966,9 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<rdf:type rdf:resource="&fibo-fbc-fct-mkt;MarketIdentifierCodeStatus"/>
 		<rdfs:label>updated MIC status</rdfs:label>
 		<skos:definition>as of the last report or update, the exchange code was revised</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UPDATED</fibo-fnd-rel-rel:hasTag>
 		<cmns-av:adaptedFrom>ISO 10383, Securities and related financial instruments - Codes for exchanges and market identification (MIC), Third edition, version 2.0</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>https://www.iso20022.org/sites/default/files/2021-12/ISO10383_MIC_Release_2_0_Factsheet.pdf</cmns-av:adaptedFrom>
+		<cmns-dsg:hasTag>UPDATED</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-mkt;hasFacilityAcronym">

--- a/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
@@ -39,6 +40,7 @@
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
@@ -99,6 +101,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
@@ -108,7 +111,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20251002/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260701/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgenciess.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgenciess.rdf version of this ontology was revised to update the GLEIF LEI registration information for the Bank of Canada, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
@@ -124,6 +127,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of the ontology was modified to further reflect changes made in Commons v1.2 (FBC-338) and eliminate unused references and streamline representation (SEC-205).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251001/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of the ontology was modified to merge details from the old corporations ontology into corporate bodies for consistency and useability (BE-259).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251002/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of the ontology was modified to integrate content from the new Commercial Registration Authorities ontology, thus eliminating certain circular dependencies (FND-407).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20260301/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of the ontology was modified to to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2017-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2017-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -133,7 +137,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Bank of Canada legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for the Bank of Canada</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300PN6MKI0CLP4T28</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300PN6MKI0CLP4T28</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cajrga;BankOfCanada"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BusinessEntityData"/>
 	</owl:NamedIndividual>

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -117,7 +117,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260602/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260701/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/20230301/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of the ontology was modified to eliminate deprecations that are more than 6 months old, primarily related to name changes to better map to the legislation that defines the concepts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
@@ -136,6 +136,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of the ontology was modified to further reflect changes made in Commons v1.2 (FBC-338) and eliminate unused references and streamline representation (SEC-205).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251001/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of the ontology was modified to merge details from the old corporations ontology into corporate bodies for consistency and useability (BE-259).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251002/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of the ontology was modified to improve clarity, eliminate circularity due to migration of the original US Financial Services Entities Individuals to Commercial Registration Authorities, and for better alignment with the GLEIF LEI repository for broader FIBO usage (FND-407).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20260202/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of the ontology was modified to eliminate the use of duplicate properties now available in Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2020-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2020-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -145,7 +146,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Federal Reserve Bank of New York legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for the Federal Reserve Bank of New York</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>254900Y8NKGV541U8Q32</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>254900Y8NKGV541U8Q32</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveBankOfNewYork-US-NY"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;BloombergFinanceLPAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -169,7 +170,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Corporation Service Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for the Corporation Service Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>549300NOPSIMGJNT8J31</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>549300NOPSIMGJNT8J31</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany-US-DE"/>
 		<cmns-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-cra;UbisecureAsLocalOperatingUnit"/>
 	</owl:NamedIndividual>
@@ -271,7 +272,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>ABA business entity identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for the American Bankers Association (ABA)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3409652</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3409652</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;AmericanBankersAssociation"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -373,7 +374,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Accuity Inc. business entity identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for Accuity Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4069925</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4069925</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;AccuityInc-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -431,7 +432,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>RSSD identifier for Bloomberg L.P.</rdfs:label>
 		<skos:definition>Federal Reserve RSSD identifier for Bloomberg L.P. as a data processing servicer</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>2217129</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>2217129</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;BloombergLP"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
 	</owl:NamedIndividual>
@@ -533,7 +534,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the California Business Entities Registry</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000598</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>RA000598</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
 	
@@ -620,7 +621,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Corporation Service Company business entity identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for the Corporation Service Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>101330</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>101330</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -654,7 +655,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>Corporation Trust Company business entity identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for The Corporation Trust Company (CT Corporation)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>101330</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>101330</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
@@ -678,7 +679,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-be-le-cb;RegistrationIdentifier"/>
 		<rdfs:label>The Depository Trust &amp; Clearing Corporation business entity identifier</rdfs:label>
 		<skos:definition>Delaware Department of Corporations business entity identifier for The Depository Trust &amp; Clearing Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>628925</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>628925</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;DTCC-US-DE"/>
 		<cmns-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
@@ -687,7 +688,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>DTC FDIC certificate number</rdfs:label>
 		<skos:definition>FDIC certificate number for The Depository Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>90544</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>90544</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;DepositoryTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -695,7 +696,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;ResearchStatisticsSupervisionDiscountIdentifier"/>
 		<rdfs:label>RSSD identifier for The Depository Trust Company</rdfs:label>
 		<skos:definition>Federal Reserve RSSD identifier for The Depository Trust Company (DTC)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>52719</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>52719</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;DepositoryTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -703,7 +704,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>The Depository Trust Company RTN</rdfs:label>
 		<skos:definition>Routing Transit Number (RTN) for the Depository Trust Company (DTC)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>026002066</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>026002066</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-cra;DepositoryTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -761,7 +762,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the Delaware Business Entities Registry</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000602</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>RA000602</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
 	
@@ -807,7 +808,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>FDIC business entity identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for the FDIC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>1003818</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>1003818</cmns-dsg:hasTag>
 		<cmns-dsg:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalDepositInsuranceCorporation"/>
 		<cmns-rga:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
@@ -1211,7 +1212,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve eighth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the eighth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of St. Louis</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>8</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>8</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Eighth District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveEighthDistrict"/>
 	</owl:NamedIndividual>
@@ -1232,7 +1233,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve eleventh district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the eleventh district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Dallas</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>11</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>11</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Eleventh District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveEleventhDistrict"/>
 	</owl:NamedIndividual>
@@ -1255,7 +1256,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve fifth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the fifth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Richmond</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>5</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Fifth District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFifthDistrict"/>
 	</owl:NamedIndividual>
@@ -1276,7 +1277,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve first district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the first district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Boston</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>1</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>1</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>First District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFirstDistrict"/>
 	</owl:NamedIndividual>
@@ -1298,7 +1299,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve fourth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the fourth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Cleveland</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>4</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Fourth District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFourthDistrict"/>
 	</owl:NamedIndividual>
@@ -1322,7 +1323,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve ninth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the ninth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Minneapolis</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>9</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>9</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Ninth District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveNinthDistrict"/>
 	</owl:NamedIndividual>
@@ -1357,7 +1358,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve second district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the second district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of New York</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>2</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>2</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Second District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSecondDistrict"/>
 	</owl:NamedIndividual>
@@ -1380,7 +1381,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve seventh district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the seventh district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Chicago</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>7</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>7</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Seventh District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSeventhDistrict"/>
 	</owl:NamedIndividual>
@@ -1404,7 +1405,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve sixth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the sixth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Atlanta</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>6</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>6</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Sixth District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSixthDistrict"/>
 	</owl:NamedIndividual>
@@ -1516,7 +1517,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve tenth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the tenth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Kansas City</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>10</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>10</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Tenth District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveTenthDistrict"/>
 	</owl:NamedIndividual>
@@ -1537,7 +1538,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve third district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the third district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Philadelphia</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>3</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Third District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveThirdDistrict"/>
 	</owl:NamedIndividual>
@@ -1567,7 +1568,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve twelfth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the twelfth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of San Francisco</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>12</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>12</cmns-dsg:hasTag>
 		<cmns-dsg:hasTextualName>Twelfth District of the Federal Reserve System</cmns-dsg:hasTextualName>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveTwelfthDistrict"/>
 	</owl:NamedIndividual>
@@ -1713,7 +1714,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the Massachusetts Corporation Registry</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000613</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>RA000613</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsCorporationRegistry"/>
 	</owl:NamedIndividual>
 	
@@ -1844,7 +1845,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the New York State (NYS) Department of State, Division of Corporations, State Records and Uniform Commercial Code (UCC) registry of business entities</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000628</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>RA000628</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
 	
@@ -1943,7 +1944,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the Ohio Business Filing Portal</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000629</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>RA000629</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal"/>
 	</owl:NamedIndividual>
 	
@@ -2123,7 +2124,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the South Dakota Business Information Registry</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000635</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>RA000635</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessInformationRegistry"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -153,7 +153,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20241101/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to use new constructs from the Commons 1.3 Business Authorizations ontology (FND-401).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251201/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to add the concept of a chart of accounts (FND-398).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251201/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to reflect migration of concepts from accounting equity to ownership in FND (FND-409) and to reflect definition refinement in financial products and services (SEC-219).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251201/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to reflect migration of concepts from accounting equity to ownership in FND (FND-409), to reflect definition refinement in financial products and services (SEC-219), and to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -993,7 +993,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -1104,7 +1104,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -1118,7 +1118,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FND/Accounting/CurrencyAmount.rdf
+++ b/FND/Accounting/CurrencyAmount.rdf
@@ -12,7 +12,6 @@
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -33,7 +32,6 @@
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -46,17 +44,16 @@
 		<dct:abstract>This ontology defines currency and monetary amount related concepts for use in defining other FIBO ontology elements. There are two distinct kinds of concepts that correspond to money and amounts: a concrete, actual amount of money, and the monetary measure of something denominated in some currency. These are dimensionally the same but whereas &apos;money amount&apos; is defined as an amount of money, &apos;monetary amount&apos; is an abstract monetary measure.
 
 The definition of currency provided herein is compliant with the definitions given in ISO 4217. ISO 4217 provides universally applicable coded representations of names of currencies and funds, used internationally for financial transaction support. The ontology has been partitioned into 2 parts: (1) the essential concept system describing the standard (this module), and (2) ISO4217-1-CurrencyCodes, which contains all of the individuals specified in ISO 4217.</dct:abstract>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
+		<dct:license>2013-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
@@ -68,7 +65,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250701/Accounting/CurrencyAmount/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/Accounting/CurrencyAmount/"/>
 		<skos:changeNote>The FIBO FND 1.0 (https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Accounting/CurrencyAmount.rdf) version of this ontology was modified per the additions introduced in the FIBO FBC RFC and related issue resolutions identified in the FIBO FND 1.1 RTF report and https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.1/, including adding support for ISO 4217 currency codes.</skos:changeNote>
 		<skos:changeNote>The FIBO FND 1.1 (https://spec.edmcouncil.org/fibo/ontology/FND/20160201/Accounting/CurrencyAmount.rdf) version of this ontology was modified per FIBO 2.0 RFC, including the addition of a new hasMonetaryAmount property as a superproperty of others required by various FIBO domain teams and integration with LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20000601/Accounting/CurrencyAmount/ version of this ontology was modified to replace a redundant concept, calculation formula with formula.</skos:changeNote>
@@ -88,10 +85,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231101/Accounting/CurrencyAmount.rdf version of this ontology was modified to tease out the distinction between the nominal and notional amount, which were confused (DER-127) and to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Accounting/CurrencyAmount.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Accounting/CurrencyAmount.rdf version of the ontology was modified to replace hasConstituent with hasMember for better semantic consistency (FND-396).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250701/Accounting/CurrencyAmount.rdf version of the ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<skos:editorialNote>(1) The present version of the ontology covers the English sections of the ISO 4217 standard only, and (2) UTF-8 character encodings are employed in names in the currency codes ontology to support the broadest number of tools.</skos:editorialNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:directSource>ISO 4217 Codes for the representation of currencies and funds, Eighth edition, 2015-08-01</cmns-av:directSource>
 		<cmns-av:directSource>ISO 4217 Codes for the representation of currencies and funds, Seventh edition, 2008-07-15</cmns-av:directSource>
 	</owl:Ontology>
@@ -177,7 +175,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-id;Identifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -241,7 +239,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-id;Identifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -335,7 +333,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-id;Identifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -367,7 +365,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-id;Identifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FND/Accounting/ISO4217-CurrencyCodes.rdf
+++ b/FND/Accounting/ISO4217-CurrencyCodes.rdf
@@ -9,7 +9,6 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-acc-4217 "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -28,7 +27,6 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-acc-4217="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -41,10 +39,10 @@
 		<rdfs:label>ISO 4217-1 Currency Codes Ontology</rdfs:label>
 		<dct:abstract>This ontology represents the subset of the ISO 4217 standard that include the actual currency codes.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2023-01-01T00:00:00</dct:issued>
-		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
+		<dct:license>Copyright (c) 2020-2026 EDM Association dba EDM Council, Inc.
 		Copyright (c) 2015-2025 Object Management Group, Inc.
-		Copyright (c) 2015-2025 Thematix Partners LLC
-		Copyright (c) 2015-2025 Copyright (c) 2022-2025 agnos.ai UK Ltd.
+		Copyright (c) 2015-2026 Thematix Partners LLC
+		Copyright (c) 2022-2026 agnos.ai UK Ltd.
 		
 		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -53,9 +51,8 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2025-03-19T00:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2026-07-15T00:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
@@ -64,7 +61,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Accounting/ISO4217-CurrencyCodes/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/Accounting/ISO4217-CurrencyCodes/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to replace Swaziland with Eswatini, which was revised by the LCC 1.1 RTF to reflect the change to the country name per the U.N.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190401/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate unnecessary dependencies on the relations ontology, and to replace rdfs:comment with skos:definition per FIBO policy.</skos:changeNote>
@@ -74,12 +71,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary and reference the latest updates to the ISO currency codes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Accounting/ISO4217-CurrencyCodes.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Accounting/ISO4217-CurrencyCodes.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Accounting/ISO4217-CurrencyCodes.rdf version of the ontology was modified to replace additional properties that are now available in the OMG Commons Ontology Library (Commons) v1.3 (FND-412).</skos:changeNote>
 		<skos:changeNote>This version was compared with and modified per the ISO XML file as published on January 1, 2023, available at https://www.six-group.com/en/products-services/financial-information/data-standards.html.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2025 Thematix Partners LLC</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2022-2025 agnos.ai UK Ltd.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2026 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2026 agnos.ai UK Ltd.</cmns-av:copyright>
 		<cmns-av:directSource>ISO 4217 Currency and funds code list, 2023-01-01, as maintained by the SNV, available at http://www.currency-iso.org/en/home.html</cmns-av:directSource>
 		<cmns-av:directSource>ISO 4217:2015 Codes for the representation of currencies and funds</cmns-av:directSource>
 		<cmns-av:explanatoryNote>This release includes all codes included in the ISO 4217 published code set.</cmns-av:explanatoryNote>
@@ -97,9 +95,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AED</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for UAE Dirham</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AED</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;UAEDirham"/>
+		<cmns-dsg:hasTag>AED</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;UAEDirham"/>
 	</owl:NamedIndividual>
 	
@@ -107,9 +105,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AFN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Afghani</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AFN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Afghani"/>
+		<cmns-dsg:hasTag>AFN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Afghani"/>
 	</owl:NamedIndividual>
 	
@@ -117,9 +115,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ALL</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Lek</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ALL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Lek"/>
+		<cmns-dsg:hasTag>ALL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Lek"/>
 	</owl:NamedIndividual>
 	
@@ -127,9 +125,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AMD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Armenian Dram</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AMD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ArmenianDram"/>
+		<cmns-dsg:hasTag>AMD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ArmenianDram"/>
 	</owl:NamedIndividual>
 	
@@ -137,9 +135,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ANG</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Netherlands Antillean Guilder</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ANG</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;NetherlandsAntilleanGuilder"/>
+		<cmns-dsg:hasTag>ANG</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;NetherlandsAntilleanGuilder"/>
 	</owl:NamedIndividual>
 	
@@ -147,9 +145,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AOA</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Kwanza</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AOA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Kwanza"/>
+		<cmns-dsg:hasTag>AOA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Kwanza"/>
 	</owl:NamedIndividual>
 	
@@ -157,9 +155,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ARS</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Argentine Peso</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ARS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ArgentinePeso"/>
+		<cmns-dsg:hasTag>ARS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ArgentinePeso"/>
 	</owl:NamedIndividual>
 	
@@ -167,9 +165,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AUD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Australian Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AUD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<cmns-dsg:hasTag>AUD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 	</owl:NamedIndividual>
 	
@@ -177,9 +175,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AWG</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Aruban Florin</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AWG</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ArubanFlorin"/>
+		<cmns-dsg:hasTag>AWG</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ArubanFlorin"/>
 	</owl:NamedIndividual>
 	
@@ -187,9 +185,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AZN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Azerbaijan Manat</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AZN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;AzerbaijanManat"/>
+		<cmns-dsg:hasTag>AZN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;AzerbaijanManat"/>
 	</owl:NamedIndividual>
 	
@@ -274,9 +272,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BAM</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Convertible Mark</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BAM</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ConvertibleMark"/>
+		<cmns-dsg:hasTag>BAM</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ConvertibleMark"/>
 	</owl:NamedIndividual>
 	
@@ -284,9 +282,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BBD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Barbados Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BarbadosDollar"/>
+		<cmns-dsg:hasTag>BBD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BarbadosDollar"/>
 	</owl:NamedIndividual>
 	
@@ -294,9 +292,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BDT</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Taka</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BDT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Taka"/>
+		<cmns-dsg:hasTag>BDT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Taka"/>
 	</owl:NamedIndividual>
 	
@@ -304,9 +302,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BGN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Bulgarian Lev</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BGN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BulgarianLev"/>
+		<cmns-dsg:hasTag>BGN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BulgarianLev"/>
 	</owl:NamedIndividual>
 	
@@ -314,9 +312,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BHD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Bahraini Dinar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BHD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BahrainiDinar"/>
+		<cmns-dsg:hasTag>BHD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BahrainiDinar"/>
 	</owl:NamedIndividual>
 	
@@ -324,9 +322,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BIF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Burundi Franc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BIF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BurundiFranc"/>
+		<cmns-dsg:hasTag>BIF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BurundiFranc"/>
 	</owl:NamedIndividual>
 	
@@ -334,9 +332,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BMD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Bermudian Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BMD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BermudianDollar"/>
+		<cmns-dsg:hasTag>BMD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BermudianDollar"/>
 	</owl:NamedIndividual>
 	
@@ -344,9 +342,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BND</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Brunei Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BND</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BruneiDollar"/>
+		<cmns-dsg:hasTag>BND</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BruneiDollar"/>
 	</owl:NamedIndividual>
 	
@@ -354,9 +352,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BOB</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Boliviano</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BOB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Boliviano"/>
+		<cmns-dsg:hasTag>BOB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Boliviano"/>
 	</owl:NamedIndividual>
 	
@@ -364,9 +362,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>BOV</rdfs:label>
 		<skos:definition xml:lang="en">the funds identifier for Mvdol</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BOV</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Mvdol"/>
+		<cmns-dsg:hasTag>BOV</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Mvdol"/>
 	</owl:NamedIndividual>
 	
@@ -374,9 +372,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BRL</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Brazilian Real</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BRL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BrazilianReal"/>
+		<cmns-dsg:hasTag>BRL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BrazilianReal"/>
 	</owl:NamedIndividual>
 	
@@ -384,9 +382,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BSD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Bahamian Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BSD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BahamianDollar"/>
+		<cmns-dsg:hasTag>BSD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BahamianDollar"/>
 	</owl:NamedIndividual>
 	
@@ -394,9 +392,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BTN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Ngultrum</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BTN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Ngultrum"/>
+		<cmns-dsg:hasTag>BTN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Ngultrum"/>
 	</owl:NamedIndividual>
 	
@@ -404,9 +402,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BWP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Pula</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BWP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Pula"/>
+		<cmns-dsg:hasTag>BWP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Pula"/>
 	</owl:NamedIndividual>
 	
@@ -414,9 +412,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BYN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Belarusian Ruble</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BYN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BelarusianRuble"/>
+		<cmns-dsg:hasTag>BYN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BelarusianRuble"/>
 	</owl:NamedIndividual>
 	
@@ -424,9 +422,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BZD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Belize Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BZD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BelizeDollar"/>
+		<cmns-dsg:hasTag>BZD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BelizeDollar"/>
 	</owl:NamedIndividual>
 	
@@ -608,9 +606,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CAD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Canadian Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CAD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<cmns-dsg:hasTag>CAD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 	</owl:NamedIndividual>
 	
@@ -618,9 +616,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CDF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Congolese Franc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CDF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CongoleseFranc"/>
+		<cmns-dsg:hasTag>CDF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CongoleseFranc"/>
 	</owl:NamedIndividual>
 	
@@ -672,9 +670,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>CHE</rdfs:label>
 		<skos:definition xml:lang="en">the funds identifier for WIR Euro</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;WIREuro"/>
+		<cmns-dsg:hasTag>CHE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;WIREuro"/>
 	</owl:NamedIndividual>
 	
@@ -682,9 +680,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CHF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Swiss Franc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<cmns-dsg:hasTag>CHF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 	</owl:NamedIndividual>
 	
@@ -692,9 +690,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>CHW</rdfs:label>
 		<skos:definition xml:lang="en">the funds identifier for WIR Franc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHW</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;WIRFranc"/>
+		<cmns-dsg:hasTag>CHW</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;WIRFranc"/>
 	</owl:NamedIndividual>
 	
@@ -702,9 +700,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>CLF</rdfs:label>
 		<skos:definition xml:lang="en">the funds identifier for Unidad de Fomento</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CLF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;UnidaddeFomento"/>
+		<cmns-dsg:hasTag>CLF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;UnidaddeFomento"/>
 	</owl:NamedIndividual>
 	
@@ -712,9 +710,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CLP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Chilean Peso</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CLP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ChileanPeso"/>
+		<cmns-dsg:hasTag>CLP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ChileanPeso"/>
 	</owl:NamedIndividual>
 	
@@ -722,9 +720,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CNY</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Yuan Renminbi</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CNY</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+		<cmns-dsg:hasTag>CNY</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 	</owl:NamedIndividual>
 	
@@ -732,9 +730,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>COP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Colombian Peso</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>COP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ColombianPeso"/>
+		<cmns-dsg:hasTag>COP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ColombianPeso"/>
 	</owl:NamedIndividual>
 	
@@ -742,9 +740,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>COU</rdfs:label>
 		<skos:definition xml:lang="en">the funds identifier for Unidad de Valor Real</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>COU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;UnidaddeValorReal"/>
+		<cmns-dsg:hasTag>COU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;UnidaddeValorReal"/>
 	</owl:NamedIndividual>
 	
@@ -752,9 +750,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CRC</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Costa Rican Colon</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CRC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CostaRicanColon"/>
+		<cmns-dsg:hasTag>CRC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CostaRicanColon"/>
 	</owl:NamedIndividual>
 	
@@ -762,9 +760,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CUC</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Peso Convertible</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CUC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;PesoConvertible"/>
+		<cmns-dsg:hasTag>CUC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;PesoConvertible"/>
 	</owl:NamedIndividual>
 	
@@ -772,9 +770,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CUP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Cuban Peso</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CUP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CubanPeso"/>
+		<cmns-dsg:hasTag>CUP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CubanPeso"/>
 	</owl:NamedIndividual>
 	
@@ -782,9 +780,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CVE</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Cabo Verde Escudo</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CVE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CaboVerdeEscudo"/>
+		<cmns-dsg:hasTag>CVE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CaboVerdeEscudo"/>
 	</owl:NamedIndividual>
 	
@@ -792,9 +790,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CZK</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Czech Koruna</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CZK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
+		<cmns-dsg:hasTag>CZK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
 	</owl:NamedIndividual>
 	
@@ -922,9 +920,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>DJF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Djibouti Franc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DJF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;DjiboutiFranc"/>
+		<cmns-dsg:hasTag>DJF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;DjiboutiFranc"/>
 	</owl:NamedIndividual>
 	
@@ -932,9 +930,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>DKK</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Danish Krone</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DKK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
+		<cmns-dsg:hasTag>DKK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
 	</owl:NamedIndividual>
 	
@@ -942,9 +940,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>DOP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Dominican Peso</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DOP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;DominicanPeso"/>
+		<cmns-dsg:hasTag>DOP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;DominicanPeso"/>
 	</owl:NamedIndividual>
 	
@@ -952,9 +950,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>DZD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Algerian Dinar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DZD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;AlgerianDinar"/>
+		<cmns-dsg:hasTag>DZD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;AlgerianDinar"/>
 	</owl:NamedIndividual>
 	
@@ -1034,9 +1032,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>EGP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Egyptian Pound</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>EGP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;EgyptianPound"/>
+		<cmns-dsg:hasTag>EGP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;EgyptianPound"/>
 	</owl:NamedIndividual>
 	
@@ -1044,9 +1042,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ERN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Nakfa</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ERN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Nakfa"/>
+		<cmns-dsg:hasTag>ERN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Nakfa"/>
 	</owl:NamedIndividual>
 	
@@ -1054,9 +1052,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ETB</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Ethiopian Birr</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ETB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;EthiopianBirr"/>
+		<cmns-dsg:hasTag>ETB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;EthiopianBirr"/>
 	</owl:NamedIndividual>
 	
@@ -1064,9 +1062,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>EUR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Euro</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>EUR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<cmns-dsg:hasTag>EUR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 	</owl:NamedIndividual>
 	
@@ -1165,9 +1163,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>FJD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Fiji Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>FJD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;FijiDollar"/>
+		<cmns-dsg:hasTag>FJD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;FijiDollar"/>
 	</owl:NamedIndividual>
 	
@@ -1175,9 +1173,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>FKP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Falkland Islands Pound</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>FKP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;FalklandIslandsPound"/>
+		<cmns-dsg:hasTag>FKP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;FalklandIslandsPound"/>
 	</owl:NamedIndividual>
 	
@@ -1215,9 +1213,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GBP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Pound Sterling</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GBP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<cmns-dsg:hasTag>GBP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 	</owl:NamedIndividual>
 	
@@ -1225,9 +1223,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GEL</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Lari</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GEL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Lari"/>
+		<cmns-dsg:hasTag>GEL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Lari"/>
 	</owl:NamedIndividual>
 	
@@ -1235,9 +1233,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GHS</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Ghana Cedi</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GHS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;GhanaCedi"/>
+		<cmns-dsg:hasTag>GHS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;GhanaCedi"/>
 	</owl:NamedIndividual>
 	
@@ -1245,9 +1243,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GIP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Gibraltar Pound</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GIP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;GibraltarPound"/>
+		<cmns-dsg:hasTag>GIP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;GibraltarPound"/>
 	</owl:NamedIndividual>
 	
@@ -1255,9 +1253,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GMD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Dalasi</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GMD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Dalasi"/>
+		<cmns-dsg:hasTag>GMD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Dalasi"/>
 	</owl:NamedIndividual>
 	
@@ -1265,9 +1263,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GNF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Guinean Franc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GNF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;GuineanFranc"/>
+		<cmns-dsg:hasTag>GNF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;GuineanFranc"/>
 	</owl:NamedIndividual>
 	
@@ -1275,9 +1273,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GTQ</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Quetzal</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GTQ</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Quetzal"/>
+		<cmns-dsg:hasTag>GTQ</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Quetzal"/>
 	</owl:NamedIndividual>
 	
@@ -1285,9 +1283,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GYD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Guyana Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GYD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;GuyanaDollar"/>
+		<cmns-dsg:hasTag>GYD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;GuyanaDollar"/>
 	</owl:NamedIndividual>
 	
@@ -1363,9 +1361,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>HKD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Hong Kong Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HKD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<cmns-dsg:hasTag>HKD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 	</owl:NamedIndividual>
 	
@@ -1373,9 +1371,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>HNL</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Lempira</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HNL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Lempira"/>
+		<cmns-dsg:hasTag>HNL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Lempira"/>
 	</owl:NamedIndividual>
 	
@@ -1384,9 +1382,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>HRK</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<skos:definition xml:lang="en">the currency identifier for Kuna</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HRK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Kuna"/>
+		<cmns-dsg:hasTag>HRK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Kuna"/>
 	</owl:NamedIndividual>
 	
@@ -1394,9 +1392,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>HTG</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Gourde</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HTG</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Gourde"/>
+		<cmns-dsg:hasTag>HTG</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Gourde"/>
 	</owl:NamedIndividual>
 	
@@ -1404,9 +1402,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>HUF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Forint</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HUF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Forint"/>
+		<cmns-dsg:hasTag>HUF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Forint"/>
 	</owl:NamedIndividual>
 	
@@ -1434,9 +1432,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>IDR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Rupiah</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IDR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
+		<cmns-dsg:hasTag>IDR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 	</owl:NamedIndividual>
 	
@@ -1444,9 +1442,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ILS</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for New Israeli Sheqel</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ILS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;NewIsraeliSheqel"/>
+		<cmns-dsg:hasTag>ILS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;NewIsraeliSheqel"/>
 	</owl:NamedIndividual>
 	
@@ -1454,9 +1452,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>INR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Indian Rupee</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>INR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<cmns-dsg:hasTag>INR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 	</owl:NamedIndividual>
 	
@@ -1464,9 +1462,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>IQD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Iraqi Dinar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IQD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;IraqiDinar"/>
+		<cmns-dsg:hasTag>IQD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;IraqiDinar"/>
 	</owl:NamedIndividual>
 	
@@ -1474,9 +1472,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>IRR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Iranian Rial</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IRR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;IranianRial"/>
+		<cmns-dsg:hasTag>IRR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;IranianRial"/>
 	</owl:NamedIndividual>
 	
@@ -1484,9 +1482,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ISK</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Iceland Krona</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ISK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;IcelandKrona"/>
+		<cmns-dsg:hasTag>ISK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;IcelandKrona"/>
 	</owl:NamedIndividual>
 	
@@ -1542,9 +1540,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>JMD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Jamaican Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>JMD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;JamaicanDollar"/>
+		<cmns-dsg:hasTag>JMD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;JamaicanDollar"/>
 	</owl:NamedIndividual>
 	
@@ -1552,9 +1550,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>JOD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Jordanian Dinar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>JOD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;JordanianDinar"/>
+		<cmns-dsg:hasTag>JOD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;JordanianDinar"/>
 	</owl:NamedIndividual>
 	
@@ -1562,9 +1560,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>JPY</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Yen</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>JPY</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<cmns-dsg:hasTag>JPY</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 	</owl:NamedIndividual>
 	
@@ -1592,9 +1590,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KES</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Kenyan Shilling</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KES</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;KenyanShilling"/>
+		<cmns-dsg:hasTag>KES</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;KenyanShilling"/>
 	</owl:NamedIndividual>
 	
@@ -1602,9 +1600,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KGS</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Som</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KGS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Som"/>
+		<cmns-dsg:hasTag>KGS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Som"/>
 	</owl:NamedIndividual>
 	
@@ -1612,9 +1610,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KHR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Riel</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KHR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Riel"/>
+		<cmns-dsg:hasTag>KHR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Riel"/>
 	</owl:NamedIndividual>
 	
@@ -1622,9 +1620,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KMF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Comorian Franc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KMF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ComorianFranc"/>
+		<cmns-dsg:hasTag>KMF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ComorianFranc"/>
 	</owl:NamedIndividual>
 	
@@ -1632,9 +1630,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KPW</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for North Korean Won</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KPW</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;NorthKoreanWon"/>
+		<cmns-dsg:hasTag>KPW</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;NorthKoreanWon"/>
 	</owl:NamedIndividual>
 	
@@ -1642,9 +1640,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KRW</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Won</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KRW</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Won"/>
+		<cmns-dsg:hasTag>KRW</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Won"/>
 	</owl:NamedIndividual>
 	
@@ -1652,9 +1650,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KWD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Kuwaiti Dinar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KWD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;KuwaitiDinar"/>
+		<cmns-dsg:hasTag>KWD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;KuwaitiDinar"/>
 	</owl:NamedIndividual>
 	
@@ -1662,9 +1660,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KYD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Cayman Islands Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KYD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CaymanIslandsDollar"/>
+		<cmns-dsg:hasTag>KYD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CaymanIslandsDollar"/>
 	</owl:NamedIndividual>
 	
@@ -1672,9 +1670,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KZT</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Tenge</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KZT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Tenge"/>
+		<cmns-dsg:hasTag>KZT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Tenge"/>
 	</owl:NamedIndividual>
 	
@@ -1745,9 +1743,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LAK</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Lao Kip</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>LAK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;LaoKip"/>
+		<cmns-dsg:hasTag>LAK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;LaoKip"/>
 	</owl:NamedIndividual>
 	
@@ -1755,9 +1753,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LBP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Lebanese Pound</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>LBP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;LebanesePound"/>
+		<cmns-dsg:hasTag>LBP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;LebanesePound"/>
 	</owl:NamedIndividual>
 	
@@ -1765,9 +1763,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LKR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Sri Lanka Rupee</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>LKR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SriLankaRupee"/>
+		<cmns-dsg:hasTag>LKR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SriLankaRupee"/>
 	</owl:NamedIndividual>
 	
@@ -1775,9 +1773,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LRD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Liberian Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>LRD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;LiberianDollar"/>
+		<cmns-dsg:hasTag>LRD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;LiberianDollar"/>
 	</owl:NamedIndividual>
 	
@@ -1785,9 +1783,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LSL</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Loti</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>LSL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Loti"/>
+		<cmns-dsg:hasTag>LSL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Loti"/>
 	</owl:NamedIndividual>
 	
@@ -1795,9 +1793,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LYD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Libyan Dinar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>LYD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;LibyanDinar"/>
+		<cmns-dsg:hasTag>LYD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;LibyanDinar"/>
 	</owl:NamedIndividual>
 	
@@ -1907,9 +1905,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MAD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Moroccan Dirham</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MAD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;MoroccanDirham"/>
+		<cmns-dsg:hasTag>MAD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;MoroccanDirham"/>
 	</owl:NamedIndividual>
 	
@@ -1917,9 +1915,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MDL</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Moldovan Leu</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MDL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;MoldovanLeu"/>
+		<cmns-dsg:hasTag>MDL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;MoldovanLeu"/>
 	</owl:NamedIndividual>
 	
@@ -1927,9 +1925,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MGA</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Malagasy Ariary</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MGA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;MalagasyAriary"/>
+		<cmns-dsg:hasTag>MGA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;MalagasyAriary"/>
 	</owl:NamedIndividual>
 	
@@ -1937,9 +1935,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MKD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Denar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MKD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Denar"/>
+		<cmns-dsg:hasTag>MKD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Denar"/>
 	</owl:NamedIndividual>
 	
@@ -1947,9 +1945,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MMK</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Kyat</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MMK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Kyat"/>
+		<cmns-dsg:hasTag>MMK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Kyat"/>
 	</owl:NamedIndividual>
 	
@@ -1957,9 +1955,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MNT</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Tugrik</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MNT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Tugrik"/>
+		<cmns-dsg:hasTag>MNT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Tugrik"/>
 	</owl:NamedIndividual>
 	
@@ -1967,9 +1965,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MOP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Pataca</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MOP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Pataca"/>
+		<cmns-dsg:hasTag>MOP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Pataca"/>
 	</owl:NamedIndividual>
 	
@@ -1977,9 +1975,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MRU</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Ouguiya</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MRU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Ouguiya"/>
+		<cmns-dsg:hasTag>MRU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Ouguiya"/>
 	</owl:NamedIndividual>
 	
@@ -1987,9 +1985,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MUR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Mauritius Rupee</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MUR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;MauritiusRupee"/>
+		<cmns-dsg:hasTag>MUR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;MauritiusRupee"/>
 	</owl:NamedIndividual>
 	
@@ -1997,9 +1995,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MVR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Rufiyaa</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MVR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Rufiyaa"/>
+		<cmns-dsg:hasTag>MVR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Rufiyaa"/>
 	</owl:NamedIndividual>
 	
@@ -2007,9 +2005,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MWK</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Malawi Kwacha</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MWK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;MalawiKwacha"/>
+		<cmns-dsg:hasTag>MWK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;MalawiKwacha"/>
 	</owl:NamedIndividual>
 	
@@ -2017,9 +2015,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MXN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Mexican Peso</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MXN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
+		<cmns-dsg:hasTag>MXN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
 	</owl:NamedIndividual>
 	
@@ -2027,9 +2025,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>MXV</rdfs:label>
 		<skos:definition xml:lang="en">the funds identifier for Mexican Unidad de Inversion (UDI)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MXV</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;MexicanUnidaddeInversion_UDI"/>
+		<cmns-dsg:hasTag>MXV</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;MexicanUnidaddeInversion_UDI"/>
 	</owl:NamedIndividual>
 	
@@ -2037,9 +2035,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MYR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Malaysian Ringgit</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MYR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
+		<cmns-dsg:hasTag>MYR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
 	</owl:NamedIndividual>
 	
@@ -2047,9 +2045,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MZN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Mozambique Metical</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MZN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;MozambiqueMetical"/>
+		<cmns-dsg:hasTag>MZN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;MozambiqueMetical"/>
 	</owl:NamedIndividual>
 	
@@ -2162,9 +2160,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NAD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Namibia Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NAD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;NamibiaDollar"/>
+		<cmns-dsg:hasTag>NAD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;NamibiaDollar"/>
 	</owl:NamedIndividual>
 	
@@ -2172,9 +2170,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NGN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Naira</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NGN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Naira"/>
+		<cmns-dsg:hasTag>NGN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Naira"/>
 	</owl:NamedIndividual>
 	
@@ -2182,9 +2180,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NIO</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Cordoba Oro</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NIO</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CordobaOro"/>
+		<cmns-dsg:hasTag>NIO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CordobaOro"/>
 	</owl:NamedIndividual>
 	
@@ -2192,9 +2190,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NOK</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Norwegian Krone</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NOK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
+		<cmns-dsg:hasTag>NOK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
 	</owl:NamedIndividual>
 	
@@ -2202,9 +2200,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NPR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Nepalese Rupee</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;NepaleseRupee"/>
+		<cmns-dsg:hasTag>NPR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;NepaleseRupee"/>
 	</owl:NamedIndividual>
 	
@@ -2212,9 +2210,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NZD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for New Zealand Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NZD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<cmns-dsg:hasTag>NZD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
 	</owl:NamedIndividual>
 	
@@ -2339,9 +2337,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>OMR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Rial Omani</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>OMR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;RialOmani"/>
+		<cmns-dsg:hasTag>OMR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;RialOmani"/>
 	</owl:NamedIndividual>
 	
@@ -2359,9 +2357,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PAB</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Balboa</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PAB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Balboa"/>
+		<cmns-dsg:hasTag>PAB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Balboa"/>
 	</owl:NamedIndividual>
 	
@@ -2369,9 +2367,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PEN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Sol</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PEN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Sol"/>
+		<cmns-dsg:hasTag>PEN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Sol"/>
 	</owl:NamedIndividual>
 	
@@ -2379,9 +2377,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PGK</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Kina</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PGK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Kina"/>
+		<cmns-dsg:hasTag>PGK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Kina"/>
 	</owl:NamedIndividual>
 	
@@ -2389,9 +2387,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PHP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Philippine Peso</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PHP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
+		<cmns-dsg:hasTag>PHP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
 	</owl:NamedIndividual>
 	
@@ -2399,9 +2397,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PKR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Pakistan Rupee</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PKR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;PakistanRupee"/>
+		<cmns-dsg:hasTag>PKR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;PakistanRupee"/>
 	</owl:NamedIndividual>
 	
@@ -2409,9 +2407,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PLN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Zloty</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PLN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+		<cmns-dsg:hasTag>PLN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
 	</owl:NamedIndividual>
 	
@@ -2419,9 +2417,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PYG</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Guarani</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PYG</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Guarani"/>
+		<cmns-dsg:hasTag>PYG</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Guarani"/>
 	</owl:NamedIndividual>
 	
@@ -2528,9 +2526,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>QAR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Qatari Rial</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>QAR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;QatariRial"/>
+		<cmns-dsg:hasTag>QAR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;QatariRial"/>
 	</owl:NamedIndividual>
 	
@@ -2558,9 +2556,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>RON</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Romanian Leu</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RON</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
+		<cmns-dsg:hasTag>RON</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
 	</owl:NamedIndividual>
 	
@@ -2568,9 +2566,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>RSD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Serbian Dinar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RSD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SerbianDinar"/>
+		<cmns-dsg:hasTag>RSD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SerbianDinar"/>
 	</owl:NamedIndividual>
 	
@@ -2578,9 +2576,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>RUB</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Russian Ruble</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RUB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
+		<cmns-dsg:hasTag>RUB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 	</owl:NamedIndividual>
 	
@@ -2588,9 +2586,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>RWF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Rwanda Franc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RWF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;RwandaFranc"/>
+		<cmns-dsg:hasTag>RWF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;RwandaFranc"/>
 	</owl:NamedIndividual>
 	
@@ -2680,9 +2678,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SAR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Saudi Riyal</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SAR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SaudiRiyal"/>
+		<cmns-dsg:hasTag>SAR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SaudiRiyal"/>
 	</owl:NamedIndividual>
 	
@@ -2690,9 +2688,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SBD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Solomon Islands Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SBD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SolomonIslandsDollar"/>
+		<cmns-dsg:hasTag>SBD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SolomonIslandsDollar"/>
 	</owl:NamedIndividual>
 	
@@ -2700,9 +2698,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SCR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Seychelles Rupee</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SCR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SeychellesRupee"/>
+		<cmns-dsg:hasTag>SCR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SeychellesRupee"/>
 	</owl:NamedIndividual>
 	
@@ -2710,9 +2708,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SDG</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Sudanese Pound</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SDG</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SudanesePound"/>
+		<cmns-dsg:hasTag>SDG</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SudanesePound"/>
 	</owl:NamedIndividual>
 	
@@ -2728,9 +2726,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SEK</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Swedish Krona</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SEK</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
+		<cmns-dsg:hasTag>SEK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
 	</owl:NamedIndividual>
 	
@@ -2738,9 +2736,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SGD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Singapore Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SGD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<cmns-dsg:hasTag>SGD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 	</owl:NamedIndividual>
 	
@@ -2748,9 +2746,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SHP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Saint Helena Pound</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SHP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SaintHelenaPound"/>
+		<cmns-dsg:hasTag>SHP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SaintHelenaPound"/>
 	</owl:NamedIndividual>
 	
@@ -2759,9 +2757,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>SLE</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Leone</skos:definition>
 		<skos:note xml:lang="en">The Sierra Leonean LEONE (SLL) is redenominated by removing three (3) zeros from the denominations. A new currency code SLE/925 representing the new valuation (1,000 times old SLL/694) is introduced on 1st April 2022 for any internal needs during the redenomination process, and is replacing SLL as the official currency code, after the transition period to be determined. During this transition period, both the old Leone and new Leone will be in physical circulation for at least 90 days. The Bank of Sierra Leone will adopt the new code in the local system but SLL/694 shall remain in use until further notice. The Sierra Leonean currency shall continue to be the LEONE and this will not change after redenomination.</skos:note>
-		<fibo-fnd-rel-rel:hasTag>SLE</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Leone"/>
+		<cmns-dsg:hasTag>SLE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Leone"/>
 	</owl:NamedIndividual>
 	
@@ -2769,9 +2767,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SLL</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Leone</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SLL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Leone"/>
+		<cmns-dsg:hasTag>SLL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Leone"/>
 	</owl:NamedIndividual>
 	
@@ -2779,9 +2777,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SOS</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Somali Shilling</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SOS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SomaliShilling"/>
+		<cmns-dsg:hasTag>SOS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SomaliShilling"/>
 	</owl:NamedIndividual>
 	
@@ -2789,9 +2787,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SRD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Surinam Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SRD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SurinamDollar"/>
+		<cmns-dsg:hasTag>SRD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SurinamDollar"/>
 	</owl:NamedIndividual>
 	
@@ -2799,9 +2797,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SSP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for South Sudanese Pound</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SSP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SouthSudanesePound"/>
+		<cmns-dsg:hasTag>SSP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SouthSudanesePound"/>
 	</owl:NamedIndividual>
 	
@@ -2809,9 +2807,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>STN</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Dobra</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>STN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Dobra"/>
+		<cmns-dsg:hasTag>STN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Dobra"/>
 	</owl:NamedIndividual>
 	
@@ -2819,9 +2817,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SVC</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for El Salvador Colon</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SVC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ElSalvadorColon"/>
+		<cmns-dsg:hasTag>SVC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ElSalvadorColon"/>
 	</owl:NamedIndividual>
 	
@@ -2829,9 +2827,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SYP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Syrian Pound</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SYP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SyrianPound"/>
+		<cmns-dsg:hasTag>SYP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SyrianPound"/>
 	</owl:NamedIndividual>
 	
@@ -2839,9 +2837,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SZL</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Lilangeni</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SZL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Lilangeni"/>
+		<cmns-dsg:hasTag>SZL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Lilangeni"/>
 	</owl:NamedIndividual>
 	
@@ -3036,9 +3034,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>THB</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Baht</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>THB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+		<cmns-dsg:hasTag>THB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 	</owl:NamedIndividual>
 	
@@ -3046,9 +3044,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TJS</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Somoni</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TJS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Somoni"/>
+		<cmns-dsg:hasTag>TJS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Somoni"/>
 	</owl:NamedIndividual>
 	
@@ -3056,9 +3054,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TMT</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Turkmenistan New Manat</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TMT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;TurkmenistanNewManat"/>
+		<cmns-dsg:hasTag>TMT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;TurkmenistanNewManat"/>
 	</owl:NamedIndividual>
 	
@@ -3066,9 +3064,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TND</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Tunisian Dinar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TND</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;TunisianDinar"/>
+		<cmns-dsg:hasTag>TND</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;TunisianDinar"/>
 	</owl:NamedIndividual>
 	
@@ -3076,9 +3074,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TOP</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Paʻanga</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TOP</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Paanga"/>
+		<cmns-dsg:hasTag>TOP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Paanga"/>
 	</owl:NamedIndividual>
 	
@@ -3086,9 +3084,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TRY</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Turkish Lira</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TRY</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
+		<cmns-dsg:hasTag>TRY</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 	</owl:NamedIndividual>
 	
@@ -3096,9 +3094,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TTD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Trinidad and Tobago Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TTD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;TrinidadandTobagoDollar"/>
+		<cmns-dsg:hasTag>TTD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;TrinidadandTobagoDollar"/>
 	</owl:NamedIndividual>
 	
@@ -3106,9 +3104,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TWD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for New Taiwan Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TWD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
+		<cmns-dsg:hasTag>TWD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
 	</owl:NamedIndividual>
 	
@@ -3116,9 +3114,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TZS</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Tanzanian Shilling</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TZS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;TanzanianShilling"/>
+		<cmns-dsg:hasTag>TZS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;TanzanianShilling"/>
 	</owl:NamedIndividual>
 	
@@ -3226,9 +3224,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>UAH</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Hryvnia</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UAH</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Hryvnia"/>
+		<cmns-dsg:hasTag>UAH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Hryvnia"/>
 	</owl:NamedIndividual>
 	
@@ -3236,9 +3234,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>UGX</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Uganda Shilling</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UGX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;UgandaShilling"/>
+		<cmns-dsg:hasTag>UGX</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;UgandaShilling"/>
 	</owl:NamedIndividual>
 	
@@ -3246,9 +3244,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>USD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for US Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>USD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<cmns-dsg:hasTag>USD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 	</owl:NamedIndividual>
 	
@@ -3296,9 +3294,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>USN</rdfs:label>
 		<skos:definition xml:lang="en">the funds identifier for US Dollar (Next day)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>USN</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;USDollar_Nextday"/>
+		<cmns-dsg:hasTag>USN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;USDollar_Nextday"/>
 	</owl:NamedIndividual>
 	
@@ -3306,9 +3304,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>UYI</rdfs:label>
 		<skos:definition xml:lang="en">the funds identifier for Uruguay Peso en Unidades Indexadas (UI)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UYI</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;UruguayPesoenUnidadesIndexadas_UI"/>
+		<cmns-dsg:hasTag>UYI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;UruguayPesoenUnidadesIndexadas_UI"/>
 	</owl:NamedIndividual>
 	
@@ -3316,9 +3314,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>UYU</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Peso Uruguayo</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UYU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;PesoUruguayo"/>
+		<cmns-dsg:hasTag>UYU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;PesoUruguayo"/>
 	</owl:NamedIndividual>
 	
@@ -3326,9 +3324,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>UYW</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Unidad Previsional</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UYW</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;UnidadPrevisional"/>
+		<cmns-dsg:hasTag>UYW</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;UnidadPrevisional"/>
 	</owl:NamedIndividual>
 	
@@ -3336,9 +3334,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>UZS</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Uzbekistan Sum</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UZS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;UzbekistanSum"/>
+		<cmns-dsg:hasTag>UZS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;UzbekistanSum"/>
 	</owl:NamedIndividual>
 	
@@ -3415,9 +3413,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>VED</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Bolívar Soberano</skos:definition>
 		<skos:note xml:lang="en">Note that the numeric currency code corresponding to the Bolívar Soberano with currency code &apos;VED&apos; is 926.</skos:note>
-		<fibo-fnd-rel-rel:hasTag>VED</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BolívarSoberano"/>
+		<cmns-dsg:hasTag>VED</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BolívarSoberano"/>
 	</owl:NamedIndividual>
 	
@@ -3426,9 +3424,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>VES</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Bolívar Soberano</skos:definition>
 		<skos:note xml:lang="en">Note that the numeric currency code corresponding to the Bolívar Soberano with currency code &apos;VES&apos; is 928.</skos:note>
-		<fibo-fnd-rel-rel:hasTag>VES</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BolívarSoberano"/>
+		<cmns-dsg:hasTag>VES</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BolívarSoberano"/>
 	</owl:NamedIndividual>
 	
@@ -3436,9 +3434,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>VND</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Dong</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>VND</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Dong"/>
+		<cmns-dsg:hasTag>VND</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Dong"/>
 	</owl:NamedIndividual>
 	
@@ -3446,9 +3444,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>VUV</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Vatu</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>VUV</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Vatu"/>
+		<cmns-dsg:hasTag>VUV</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Vatu"/>
 	</owl:NamedIndividual>
 	
@@ -3490,9 +3488,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>WST</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Tala</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WST</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Tala"/>
+		<cmns-dsg:hasTag>WST</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Tala"/>
 	</owl:NamedIndividual>
 	
@@ -3510,9 +3508,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XAF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for CFA Franc BEAC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XAF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CFAFrancBEAC"/>
+		<cmns-dsg:hasTag>XAF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CFAFrancBEAC"/>
 	</owl:NamedIndividual>
 	
@@ -3520,9 +3518,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;PreciousMetalIdentifier"/>
 		<rdfs:label>XAG</rdfs:label>
 		<skos:definition xml:lang="en">identifier for the currency whose unit is one troy ounce of the precious metal Silver</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XAG</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Silver"/>
+		<cmns-dsg:hasTag>XAG</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Silver"/>
 	</owl:NamedIndividual>
 	
@@ -3530,9 +3528,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;PreciousMetalIdentifier"/>
 		<rdfs:label>XAU</rdfs:label>
 		<skos:definition xml:lang="en">identifier for the currency whose unit is one troy ounce of the precious metal Gold</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XAU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Gold"/>
+		<cmns-dsg:hasTag>XAU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Gold"/>
 	</owl:NamedIndividual>
 	
@@ -3540,9 +3538,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XBA</rdfs:label>
 		<skos:definition xml:lang="en">the identifier for Bond Markets Unit European Composite Unit (EURCO)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XBA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanCompositeUnit_EURCO"/>
+		<cmns-dsg:hasTag>XBA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanCompositeUnit_EURCO"/>
 	</owl:NamedIndividual>
 	
@@ -3550,9 +3548,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XBB</rdfs:label>
 		<skos:definition xml:lang="en">the identifier for Bond Markets Unit European Monetary Unit (E.M.U.-6)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XBB</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanMonetaryUnit_EMU-6"/>
+		<cmns-dsg:hasTag>XBB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanMonetaryUnit_EMU-6"/>
 	</owl:NamedIndividual>
 	
@@ -3560,9 +3558,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XBC</rdfs:label>
 		<skos:definition xml:lang="en">the identifier for Bond Markets Unit European Unit of Account 9 (E.U.A.-9)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XBC</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanUnitofAccount9_EUA-9"/>
+		<cmns-dsg:hasTag>XBC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanUnitofAccount9_EUA-9"/>
 	</owl:NamedIndividual>
 	
@@ -3570,9 +3568,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XBD</rdfs:label>
 		<skos:definition xml:lang="en">the identifier for Bond Markets Unit European Unit of Account 17 (E.U.A.-17)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XBD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanUnitofAccount17_EUA-17"/>
+		<cmns-dsg:hasTag>XBD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanUnitofAccount17_EUA-17"/>
 	</owl:NamedIndividual>
 	
@@ -3580,9 +3578,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XCD</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for East Caribbean Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XCD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;EastCaribbeanDollar"/>
+		<cmns-dsg:hasTag>XCD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;EastCaribbeanDollar"/>
 	</owl:NamedIndividual>
 	
@@ -3590,9 +3588,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XDR</rdfs:label>
 		<skos:definition xml:lang="en">the IMF&apos;s identifier for SDR (Special Drawing Right)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XDR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;SDR_SpecialDrawingRight"/>
+		<cmns-dsg:hasTag>XDR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;SDR_SpecialDrawingRight"/>
 	</owl:NamedIndividual>
 	
@@ -3600,9 +3598,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XOF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for CFA Franc BCEAO</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XOF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CFAFrancBCEAO"/>
+		<cmns-dsg:hasTag>XOF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CFAFrancBCEAO"/>
 	</owl:NamedIndividual>
 	
@@ -3610,9 +3608,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;PreciousMetalIdentifier"/>
 		<rdfs:label>XPD</rdfs:label>
 		<skos:definition xml:lang="en">identifier for the currency whose unit is one troy ounce of the precious metal Palladium</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XPD</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Palladium"/>
+		<cmns-dsg:hasTag>XPD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Palladium"/>
 	</owl:NamedIndividual>
 	
@@ -3620,9 +3618,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XPF</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for CFP Franc</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XPF</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;CFPFranc"/>
+		<cmns-dsg:hasTag>XPF</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;CFPFranc"/>
 	</owl:NamedIndividual>
 	
@@ -3630,9 +3628,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;PreciousMetalIdentifier"/>
 		<rdfs:label>XPT</rdfs:label>
 		<skos:definition xml:lang="en">identifier for the currency whose unit is one troy ounce of the precious metal Platinum</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XPT</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Platinum"/>
+		<cmns-dsg:hasTag>XPT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Platinum"/>
 	</owl:NamedIndividual>
 	
@@ -3640,9 +3638,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XSU</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Sucre</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XSU</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Sucre"/>
+		<cmns-dsg:hasTag>XSU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Sucre"/>
 	</owl:NamedIndividual>
 	
@@ -3650,17 +3648,17 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XTS</rdfs:label>
 		<skos:definition xml:lang="en">Codes specifically reserved for testing purposes</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XTS</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
+		<cmns-dsg:hasTag>XTS</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XUA">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XUA</rdfs:label>
 		<skos:definition xml:lang="en">the identifier for ADB Unit of Account</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XUA</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ADBUnitofAccount"/>
+		<cmns-dsg:hasTag>XUA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ADBUnitofAccount"/>
 	</owl:NamedIndividual>
 	
@@ -3668,17 +3666,17 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XXX</rdfs:label>
 		<skos:definition xml:lang="en">The codes assigned for transactions where no currency is involved</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>XXX</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
+		<cmns-dsg:hasTag>XXX</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;YER">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>YER</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Yemeni Rial</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>YER</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;YemeniRial"/>
+		<cmns-dsg:hasTag>YER</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;YemeniRial"/>
 	</owl:NamedIndividual>
 	
@@ -3716,9 +3714,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ZAR</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Rand</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ZAR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;Rand"/>
+		<cmns-dsg:hasTag>ZAR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;Rand"/>
 	</owl:NamedIndividual>
 	
@@ -3726,9 +3724,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ZMW</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Zambian Kwacha</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ZMW</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ZambianKwacha"/>
+		<cmns-dsg:hasTag>ZMW</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ZambianKwacha"/>
 	</owl:NamedIndividual>
 	
@@ -3736,9 +3734,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ZWL</rdfs:label>
 		<skos:definition xml:lang="en">the currency identifier for Zimbabwe Dollar</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ZWL</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-acc-4217;ZimbabweDollar"/>
+		<cmns-dsg:hasTag>ZWL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-acc-4217;ZimbabweDollar"/>
 	</owl:NamedIndividual>
 	

--- a/FND/AgentsAndPeople/People.rdf
+++ b/FND/AgentsAndPeople/People.rdf
@@ -58,7 +58,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/People/">
 		<rdfs:label>People Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts for people and human related terms, for use in other FIBO ontology elements. People as defined here are human persons only. This ontology sets out a number of basic properties which are held by people or are definitive of a small number of specific types of people such as minors or adults. Primary use cases for determining the set of personal information definitions included are the common elements required to (1) open a bank account, (2) identify a sophisticated investor, and (3) establish foreign account ownership for money laundering purposes.</dct:abstract>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2013-2025 Object Management Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -88,7 +88,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250901/AgentsAndPeople/People/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/AgentsAndPeople/People/"/>
 		<skos:changeNote>The http://spec.edmcouncil.org/fibo/ontology/FND/20130801/AgentsAndPeople/People.rdf version of the ontology was was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/. It was further revised in the FTF in advance of the Long Beach meeting, resulting in https://spec.edmcouncil.org/fibo/ontology/FND/20141101/AgentsAndPeople/People/.</skos:changeNote>
 		<skos:changeNote>The http://spec.edmcouncil.org/fibo/ontology/FND/20141101/AgentsAndPeople/People.rdf version of the ontology was was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report, primarily to use the hasAddress property in addresses, and change PostalAddress to PhysicalAddress in a restriction on Person. Also revised the identifiesAddress property in favor of verifiesAddress, and revised hasDateofBirth with respect to an identity document to be verifiesDateOfBirth, which was determined to be more appropriate by the RTF.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/AgentsAndPeople/People.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
@@ -117,9 +117,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/AgentsAndPeople/People.rdf version of the ontology was modified to replace an additional property with its equivalent from the OMG Commons Ontology Library (Commons) v1.1 (FBC-322).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241001/AgentsAndPeople/People.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/AgentsAndPeople/People.rdf version of the ontology was modified to add the concept of a contact, as a role someone can play, and of contact record, as the representation of the details that store the relevant information (FND-397).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250901/AgentsAndPeople/People.rdf version of the ontology was modified to deprecate duplicate properties that are now available in OMG Commons Ontology Library (Commons) v1.3 (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-aap-ppl;Adult">
@@ -765,7 +766,6 @@ Many countries issued such numbers ostensibly for a singular purpose, but over t
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-aap-ppl;hasPointOfContact">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasDesignation"/>
 		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;hasRole"/>
 		<rdfs:label>has point of contact</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-aap-ppl;Contact"/>

--- a/FND/Arrangements/Ratings.rdf
+++ b/FND/Arrangements/Ratings.rdf
@@ -48,7 +48,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Ratings/">
 		<rdfs:label>Ratings Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation of ratings and rating schemes, particularly for ratings describing aspects of business performance, credit worthiness, and investment quality at a high level.</dct:abstract>
-		<dct:license>Copyright (c) 2019-2025 EDM Council, Inc.
+		<dct:license>Copyright (c) 2019-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2019-2025 Object Management Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -72,7 +72,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Arrangements/Ratings/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/Arrangements/Ratings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190601/Arrangements/Ratings.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Arrangements/Ratings.rdf version of this ontology was revised to add properties indicating the &apos;best&apos; and &apos;worst&apos; scores on a given scale.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Arrangements/Ratings.rdf version of this ontology was revised to eliminate duplication with LCC.</skos:changeNote>
@@ -84,9 +84,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Arrangements/Ratings.rdf version of the ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Arrangements/Ratings.rdf version of the ontology was modified to replace an additional property with its equivalent in the Commons Ontology Library (Commons) v1.1 (FBC-322).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241001/Arrangements/Ratings.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Arrangements/Ratings.rdf version of the ontology was modified to replace properties that are now available in the OMG Commons Ontology Library (Commons) v1.3 (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2019-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2019-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2019-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-arr-rt;QualitativeRatingScore">
@@ -94,7 +95,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -13,7 +13,6 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-arr-id "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -36,7 +35,6 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-arr-id="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -48,10 +46,10 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 		<rdfs:label>Addresses Ontology</rdfs:label>
 		<dct:abstract>This ontology provides high level definitions for addresses and address components including elements that are common to addressing standards.</dct:abstract>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
+		<dct:license>2013-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -59,7 +57,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
@@ -72,7 +69,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/SitesAndFacilities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20251201/Places/Addresses/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/Places/Addresses/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report. Differences from the 1.0 version include the addition of a hasAddress property and PhysicalAddress class as a parent of PostalAddress.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20160201/Places/Addresses.rdf version of this ontology was modified for the FIBO 2.0 RFC to integrate LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20130801/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/. Primary differences include elimination of data properties in favor of a simple class model,the addition of virtual address, and the addition of addressing scheme.</skos:changeNote>
@@ -87,6 +84,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Places/Addresses.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Places/Addresses.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Places/Addresses.rdf version of the ontology was modified to reuse concepts from the Commons 1.3 sites and facilities ontology (FND-401).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20251201/Places/Addresses.rdf version of the ontology was modified to to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/Foundations/20130601/Organizations/Addresses.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 	(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
 	(2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -95,8 +93,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	(5) to incorporate changes to the specification metadata to support documentation at the family, specification, module, and ontology level, similar to the abbreviations
 	(6) to move this ontology from Organizations to Places and eliminate unnecessary properties and related imports dependencies.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;Address">
@@ -219,7 +217,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:someValuesFrom rdf:resource="&xsd;string"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -456,7 +454,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;AddressComponent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -531,7 +529,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;AddressComponent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -620,7 +618,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-dsg;Name"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -642,7 +640,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-dsg;Name"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -670,7 +668,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&rdfs;Literal"/>
 			</owl:Restriction>
@@ -703,7 +701,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;AddressComponent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -737,7 +735,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Address"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FND/Places/NorthAmerica/USPostalServiceAddresses.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddresses.rdf
@@ -3,12 +3,12 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-uspsa "https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -20,12 +20,12 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-uspsa="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -37,10 +37,10 @@
 		<rdfs:label>U.S. Postal Service Addresses Ontology</rdfs:label>
 		<dct:abstract>This ontology augments the Addresses ontology in FND with concepts that conform to the USPS Pub 28. The USPS provides automated address verification services that use the concepts defined herein for that purpose, and which many financial services entities use for data quality purposes.</dct:abstract>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
-		<dct:license>Copyright (c) 2019-2025 EDM Council, Inc.
-		Copyright (c) 2019-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+		<dct:license>Copyright (c) 2019-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2019-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -50,22 +50,23 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://about.usps.com/who/profile/"/>
 		<rdfs:seeAlso rdf:resource="https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Places/NorthAmerica/USPostalServiceAddresses/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/Places/NorthAmerica/USPostalServiceAddresses/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/NorthAmerica/USPostalServiceAddresses.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here, and correct a duplicate label.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Places/NorthAmerica/USPostalServiceAddresses.rdf version of this ontology was revised to address hygiene issues with respect to text formatting.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/Places/NorthAmerica/USPostalServiceAddresses.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Places/NorthAmerica/USPostalServiceAddresses.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Places/NorthAmerica/USPostalServiceAddresses.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Places/NorthAmerica/USPostalServiceAddresses.rdf version of the ontology was modified to replace properties that are now available in the OMG Commons Ontology Library (Commons) v1.3 (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2019-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2019-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2019-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Apartment">
@@ -223,7 +224,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -291,7 +292,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">East</rdfs:label>
 		<rdfs:label xml:lang="es">Este</rdfs:label>
 		<skos:definition>geographic directional symbol for East</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>E</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>E</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;GeneralDeliveryAddress">
@@ -385,7 +386,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="es">Norte</rdfs:label>
 		<rdfs:label xml:lang="en">North</rdfs:label>
 		<skos:definition>geographic directional symbol for North</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>N</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>N</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Northeast">
@@ -393,7 +394,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="es">Noreste</rdfs:label>
 		<rdfs:label xml:lang="en">Northeast</rdfs:label>
 		<skos:definition>geographic directional symbol for Northeast</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NE</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>NE</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Northwest">
@@ -401,8 +402,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="es">Noroeste</rdfs:label>
 		<rdfs:label xml:lang="en">Northwest</rdfs:label>
 		<skos:definition>geographic directional symbol for Northwest</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NO</fibo-fnd-rel-rel:hasTag>
-		<fibo-fnd-rel-rel:hasTag>NW</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>NO</cmns-dsg:hasTag>
+		<cmns-dsg:hasTag>NW</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;OverseasMilitaryAddress">
@@ -502,7 +503,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">South</rdfs:label>
 		<rdfs:label xml:lang="es">Sur</rdfs:label>
 		<skos:definition>geographic directional symbol for South</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>S</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>S</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Southeast">
@@ -510,7 +511,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">Southeast</rdfs:label>
 		<rdfs:label xml:lang="es">Sureste</rdfs:label>
 		<skos:definition>geographic directional symbol for Southeast</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SE</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>SE</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Southwest">
@@ -518,8 +519,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="en">Southwest</rdfs:label>
 		<rdfs:label xml:lang="es">Suroeste</rdfs:label>
 		<skos:definition>geographic directional symbol for Southwest</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SO</fibo-fnd-rel-rel:hasTag>
-		<fibo-fnd-rel-rel:hasTag>SW</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>SO</cmns-dsg:hasTag>
+		<cmns-dsg:hasTag>SW</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;StandardizedAddress">
@@ -568,8 +569,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label xml:lang="es">Oeste</rdfs:label>
 		<rdfs:label xml:lang="en">West</rdfs:label>
 		<skos:definition>geographic directional symbol for West</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>O</fibo-fnd-rel-rel:hasTag>
-		<fibo-fnd-rel-rel:hasTag>W</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>O</cmns-dsg:hasTag>
+		<cmns-dsg:hasTag>W</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;ZIPCode">

--- a/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
@@ -10,7 +10,6 @@
 	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
 	<!ENTITY fibo-fnd-plc-uspsa "https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/">
 	<!ENTITY fibo-fnd-plc-uspsai "https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-3166-2-ca "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/">
@@ -33,7 +32,6 @@
 	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
 	xmlns:fibo-fnd-plc-uspsa="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"
 	xmlns:fibo-fnd-plc-uspsai="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-3166-2-ca="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"
@@ -49,10 +47,10 @@
 		<rdfs:label>U.S. Postal Service Addresses Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology augments the U.S. Postal Service Address ontology with individuals for various street suffixes, military and U.S. Department of State specific individuals, and preferred designations for state and territory codes.</dct:abstract>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
-		<dct:license>Copyright (c) 2019-2025 EDM Council, Inc.
-		Copyright (c) 2019-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+		<dct:license>Copyright (c) 2019-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2019-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -63,7 +61,6 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:seeAlso rdf:resource="https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
@@ -75,24 +72,25 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf version of this ontology was revised to update a dead link.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20220701/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230101/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf version of the ontology was modified to replace properties that are now available in the OMG Commons Ontology Library (Commons) v1.3 (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2019-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2019-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2019-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AA">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>AA</rdfs:label>
 		<skos:definition>US-specific code for the state designation for Armed Forces Americas, excluding Canada</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AA</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
+		<cmns-dsg:hasTag>AA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
 	</owl:NamedIndividual>
 	
@@ -100,11 +98,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>AB</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Alberta</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AB</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AB</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Alberta"/>
+		<cmns-dsg:hasTag>AB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Alberta"/>
 	</owl:NamedIndividual>
 	
@@ -112,10 +110,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>AE</rdfs:label>
 		<skos:definition>US-specific code for the state designation for Armed Forces Europe, the Middle East, and Canada</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AE</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
+		<cmns-dsg:hasTag>AE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
 	</owl:NamedIndividual>
 	
@@ -123,10 +121,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>AK</rdfs:label>
 		<skos:definition>US-specific code for the designation for Alaska</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AK</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AK</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Alaska"/>
+		<cmns-dsg:hasTag>AK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Alaska"/>
 	</owl:NamedIndividual>
 	
@@ -134,10 +132,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>AL</rdfs:label>
 		<skos:definition>US-specific code for the designation for Alabama</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AL</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AL</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Alabama"/>
+		<cmns-dsg:hasTag>AL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Alabama"/>
 	</owl:NamedIndividual>
 	
@@ -145,10 +143,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>AP</rdfs:label>
 		<skos:definition>US-specific code for the state designation for Armed Forces Pacific</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AP</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AP</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
+		<cmns-dsg:hasTag>AP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
 	</owl:NamedIndividual>
 	
@@ -156,10 +154,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>AR</rdfs:label>
 		<skos:definition>US-specific code for the designation for Arkansas</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AR</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AR</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Arkansas"/>
+		<cmns-dsg:hasTag>AR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Arkansas"/>
 	</owl:NamedIndividual>
 	
@@ -167,10 +165,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>AS</rdfs:label>
 		<skos:definition>US-specific code for the designation for American Samoa</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AS</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AS</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;AmericanSamoa"/>
+		<cmns-dsg:hasTag>AS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;AmericanSamoa"/>
 	</owl:NamedIndividual>
 	
@@ -178,10 +176,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>AZ</rdfs:label>
 		<skos:definition>US-specific code for the designation for Arizona</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>AZ</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AZ</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Arizona"/>
+		<cmns-dsg:hasTag>AZ</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Arizona"/>
 	</owl:NamedIndividual>
 	
@@ -261,11 +259,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>BC</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for British Columbia</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>BC</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;BritishColumbia"/>
+		<cmns-dsg:hasTag>BC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;BritishColumbia"/>
 	</owl:NamedIndividual>
 	
@@ -405,10 +403,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>CA</rdfs:label>
 		<skos:definition>US-specific code for the designation for California</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>CA</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;California"/>
+		<cmns-dsg:hasTag>CA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;California"/>
 	</owl:NamedIndividual>
 	
@@ -416,10 +414,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>CO</rdfs:label>
 		<skos:definition>US-specific code for the designation for Colorado</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CO</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>CO</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Colorado"/>
+		<cmns-dsg:hasTag>CO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Colorado"/>
 	</owl:NamedIndividual>
 	
@@ -427,10 +425,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>CT</rdfs:label>
 		<skos:definition>US-specific code for the designation for Connecticut</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>CT</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Connecticut"/>
+		<cmns-dsg:hasTag>CT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Connecticut"/>
 	</owl:NamedIndividual>
 	
@@ -661,10 +659,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>DC</rdfs:label>
 		<skos:definition>US-specific code for the designation for the District of Colombia</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>DC</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;DistrictOfColumbia"/>
+		<cmns-dsg:hasTag>DC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;DistrictOfColumbia"/>
 	</owl:NamedIndividual>
 	
@@ -672,10 +670,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>DE</rdfs:label>
 		<skos:definition>US-specific code for the designation for Delaware</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>DE</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Delaware"/>
+		<cmns-dsg:hasTag>DE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Delaware"/>
 	</owl:NamedIndividual>
 	
@@ -771,10 +769,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>FL</rdfs:label>
 		<skos:definition>US-specific code for the designation for Florida</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>FL</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>FL</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Florida"/>
+		<cmns-dsg:hasTag>FL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Florida"/>
 	</owl:NamedIndividual>
 	
@@ -914,10 +912,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>GA</rdfs:label>
 		<skos:definition>US-specific code for the designation for Georgia</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>GA</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Georgia"/>
+		<cmns-dsg:hasTag>GA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Georgia"/>
 	</owl:NamedIndividual>
 	
@@ -925,10 +923,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>GU</rdfs:label>
 		<skos:definition>US-specific code for the designation for Guam</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>GU</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>GU</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Guam"/>
+		<cmns-dsg:hasTag>GU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Guam"/>
 	</owl:NamedIndividual>
 	
@@ -1012,10 +1010,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>HI</rdfs:label>
 		<skos:definition>US-specific code for the designation for Hawaii</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>HI</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Hawaii"/>
+		<cmns-dsg:hasTag>HI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Hawaii"/>
 	</owl:NamedIndividual>
 	
@@ -1096,10 +1094,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>IA</rdfs:label>
 		<skos:definition>US-specific code for the designation for Iowa</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>IA</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Iowa"/>
+		<cmns-dsg:hasTag>IA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Iowa"/>
 	</owl:NamedIndividual>
 	
@@ -1107,10 +1105,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>ID</rdfs:label>
 		<skos:definition>US-specific code for the designation for Idaho</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ID</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>ID</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Idaho"/>
+		<cmns-dsg:hasTag>ID</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Idaho"/>
 	</owl:NamedIndividual>
 	
@@ -1118,10 +1116,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>IL</rdfs:label>
 		<skos:definition>US-specific code for the designation for Illinois</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IL</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>IL</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Illinois"/>
+		<cmns-dsg:hasTag>IL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Illinois"/>
 	</owl:NamedIndividual>
 	
@@ -1129,10 +1127,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>IN</rdfs:label>
 		<skos:definition>US-specific code for the designation for Indiana</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IN</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>IN</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Indiana"/>
+		<cmns-dsg:hasTag>IN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Indiana"/>
 	</owl:NamedIndividual>
 	
@@ -1194,10 +1192,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>KS</rdfs:label>
 		<skos:definition>US-specific code for the designation for Kansas</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KS</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>KS</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Kansas"/>
+		<cmns-dsg:hasTag>KS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Kansas"/>
 	</owl:NamedIndividual>
 	
@@ -1205,10 +1203,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>KY</rdfs:label>
 		<skos:definition>US-specific code for the designation for Kentucky</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>KY</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>KY</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Kentucky"/>
+		<cmns-dsg:hasTag>KY</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Kentucky"/>
 	</owl:NamedIndividual>
 	
@@ -1249,10 +1247,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>LA</rdfs:label>
 		<skos:definition>US-specific code for the designation for Louisiana</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>LA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>LA</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Louisiana"/>
+		<cmns-dsg:hasTag>LA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Louisiana"/>
 	</owl:NamedIndividual>
 	
@@ -1357,10 +1355,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>MA</rdfs:label>
 		<skos:definition>US-specific code for the designation for Massachusetts</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MA</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Massachusetts"/>
+		<cmns-dsg:hasTag>MA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Massachusetts"/>
 	</owl:NamedIndividual>
 	
@@ -1368,11 +1366,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>MB</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Manitoba</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MB</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MB</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Manitoba"/>
+		<cmns-dsg:hasTag>MB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Manitoba"/>
 	</owl:NamedIndividual>
 	
@@ -1380,10 +1378,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>MD</rdfs:label>
 		<skos:definition>US-specific code for the designation for Maryland</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MD</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MD</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Maryland"/>
+		<cmns-dsg:hasTag>MD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Maryland"/>
 	</owl:NamedIndividual>
 	
@@ -1391,10 +1389,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>ME</rdfs:label>
 		<skos:definition>US-specific code for the designation for Maine</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ME</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>ME</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Maine"/>
+		<cmns-dsg:hasTag>ME</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Maine"/>
 	</owl:NamedIndividual>
 	
@@ -1402,10 +1400,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>MI</rdfs:label>
 		<skos:definition>US-specific code for the designation for Michigan</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MI</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Michigan"/>
+		<cmns-dsg:hasTag>MI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Michigan"/>
 	</owl:NamedIndividual>
 	
@@ -1413,10 +1411,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>MN</rdfs:label>
 		<skos:definition>US-specific code for the designation for Minnesota</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MN</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MN</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Minnesota"/>
+		<cmns-dsg:hasTag>MN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Minnesota"/>
 	</owl:NamedIndividual>
 	
@@ -1424,10 +1422,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>MO</rdfs:label>
 		<skos:definition>US-specific code for the designation for Missouri</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MO</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MO</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Missouri"/>
+		<cmns-dsg:hasTag>MO</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Missouri"/>
 	</owl:NamedIndividual>
 	
@@ -1435,10 +1433,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>MP</rdfs:label>
 		<skos:definition>US-specific code for the designation for the outlying area of Northern Mariana Islands</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MP</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MP</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NorthernMarianaIslands"/>
+		<cmns-dsg:hasTag>MP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NorthernMarianaIslands"/>
 	</owl:NamedIndividual>
 	
@@ -1446,10 +1444,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>MS</rdfs:label>
 		<skos:definition>US-specific code for the designation for Mississippi</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MS</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MS</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Mississippi"/>
+		<cmns-dsg:hasTag>MS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Mississippi"/>
 	</owl:NamedIndividual>
 	
@@ -1457,10 +1455,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>MT</rdfs:label>
 		<skos:definition>US-specific code for the designation for Montana</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>MT</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Montana"/>
+		<cmns-dsg:hasTag>MT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Montana"/>
 	</owl:NamedIndividual>
 	
@@ -1573,11 +1571,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NB</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for New Brunswick</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NB</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NB</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;NewBrunswick"/>
+		<cmns-dsg:hasTag>NB</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;NewBrunswick"/>
 	</owl:NamedIndividual>
 	
@@ -1585,10 +1583,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NC</rdfs:label>
 		<skos:definition>US-specific code for the designation for North Carolina</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NC</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NorthCarolina"/>
+		<cmns-dsg:hasTag>NC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NorthCarolina"/>
 	</owl:NamedIndividual>
 	
@@ -1596,10 +1594,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>ND</rdfs:label>
 		<skos:definition>US-specific code for the designation for North Dakota</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ND</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>ND</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NorthDakota"/>
+		<cmns-dsg:hasTag>ND</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NorthDakota"/>
 	</owl:NamedIndividual>
 	
@@ -1607,10 +1605,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NE</rdfs:label>
 		<skos:definition>US-specific code for the designation for Nebraska</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NE</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Nebraska"/>
+		<cmns-dsg:hasTag>NE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Nebraska"/>
 	</owl:NamedIndividual>
 	
@@ -1618,10 +1616,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NH</rdfs:label>
 		<skos:definition>US-specific code for the designation for New Hampshire</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NH</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NH</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NewHampshire"/>
+		<cmns-dsg:hasTag>NH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NewHampshire"/>
 	</owl:NamedIndividual>
 	
@@ -1629,10 +1627,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NJ</rdfs:label>
 		<skos:definition>US-specific code for the designation for New Jersey</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NJ</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NJ</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NewJersey"/>
+		<cmns-dsg:hasTag>NJ</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NewJersey"/>
 	</owl:NamedIndividual>
 	
@@ -1640,11 +1638,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NL</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Newfoundland and Labrador</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NL</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NL</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;NewfoundlandAndLabrador"/>
+		<cmns-dsg:hasTag>NL</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;NewfoundlandAndLabrador"/>
 	</owl:NamedIndividual>
 	
@@ -1652,10 +1650,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NM</rdfs:label>
 		<skos:definition>US-specific code for the designation for New Mexico</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NM</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NM</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NewMexico"/>
+		<cmns-dsg:hasTag>NM</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NewMexico"/>
 	</owl:NamedIndividual>
 	
@@ -1663,11 +1661,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NS</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Nova Scotia</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NS</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NS</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;NovaScotia"/>
+		<cmns-dsg:hasTag>NS</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;NovaScotia"/>
 	</owl:NamedIndividual>
 	
@@ -1675,11 +1673,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NT</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Northwest Territories</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NT</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;NorthwestTerritories"/>
+		<cmns-dsg:hasTag>NT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;NorthwestTerritories"/>
 	</owl:NamedIndividual>
 	
@@ -1687,11 +1685,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NU</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Nunavut</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NU</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NU</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Nunavut"/>
+		<cmns-dsg:hasTag>NU</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Nunavut"/>
 	</owl:NamedIndividual>
 	
@@ -1699,10 +1697,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NV</rdfs:label>
 		<skos:definition>US-specific code for the designation for Nevada</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NV</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NV</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Nevada"/>
+		<cmns-dsg:hasTag>NV</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Nevada"/>
 	</owl:NamedIndividual>
 	
@@ -1710,10 +1708,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>NY</rdfs:label>
 		<skos:definition>US-specific code for the designation for New York</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NY</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>NY</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;NewYork"/>
+		<cmns-dsg:hasTag>NY</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;NewYork"/>
 	</owl:NamedIndividual>
 	
@@ -1729,10 +1727,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>OH</rdfs:label>
 		<skos:definition>US-specific code for the designation for Ohio</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>OH</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>OH</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Ohio"/>
+		<cmns-dsg:hasTag>OH</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Ohio"/>
 	</owl:NamedIndividual>
 	
@@ -1740,10 +1738,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>OK</rdfs:label>
 		<skos:definition>US-specific code for the designation for Oklahoma</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>OK</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>OK</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Oklahoma"/>
+		<cmns-dsg:hasTag>OK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Oklahoma"/>
 	</owl:NamedIndividual>
 	
@@ -1751,11 +1749,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>ON</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Ontario</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ON</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>ON</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Ontario"/>
+		<cmns-dsg:hasTag>ON</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Ontario"/>
 	</owl:NamedIndividual>
 	
@@ -1763,10 +1761,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>OR</rdfs:label>
 		<skos:definition>US-specific code for the designation for Oregon</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>OR</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>OR</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Oregon"/>
+		<cmns-dsg:hasTag>OR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Oregon"/>
 	</owl:NamedIndividual>
 	
@@ -1798,10 +1796,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>PA</rdfs:label>
 		<skos:definition>US-specific code for the designation for Pennsylvania</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>PA</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
+		<cmns-dsg:hasTag>PA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
 	</owl:NamedIndividual>
 	
@@ -1809,11 +1807,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>PE</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Prince Edward Island</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>PE</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;PrinceEdwardIsland"/>
+		<cmns-dsg:hasTag>PE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;PrinceEdwardIsland"/>
 	</owl:NamedIndividual>
 	
@@ -1821,10 +1819,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>PR</rdfs:label>
 		<skos:definition>US-specific code for the designation for Puerto Rico</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PR</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>PR</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;PuertoRico"/>
+		<cmns-dsg:hasTag>PR</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;PuertoRico"/>
 	</owl:NamedIndividual>
 	
@@ -1984,11 +1982,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>QC</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Quebec</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>QC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>QC</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Quebec"/>
+		<cmns-dsg:hasTag>QC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Quebec"/>
 	</owl:NamedIndividual>
 	
@@ -1996,10 +1994,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>RI</rdfs:label>
 		<skos:definition>US-specific code for the designation for Rhode Island</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>RI</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;RhodeIsland"/>
+		<cmns-dsg:hasTag>RI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;RhodeIsland"/>
 	</owl:NamedIndividual>
 	
@@ -2129,10 +2127,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>SC</rdfs:label>
 		<skos:definition>US-specific code for the designation for South Carolina</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>SC</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;SouthCarolina"/>
+		<cmns-dsg:hasTag>SC</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;SouthCarolina"/>
 	</owl:NamedIndividual>
 	
@@ -2140,10 +2138,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>SD</rdfs:label>
 		<skos:definition>US-specific code for the designation for South Dakota</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SD</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>SD</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;SouthDakota"/>
+		<cmns-dsg:hasTag>SD</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;SouthDakota"/>
 	</owl:NamedIndividual>
 	
@@ -2151,11 +2149,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>SK</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Saskatchewan</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SK</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>SK</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Saskatchewan"/>
+		<cmns-dsg:hasTag>SK</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Saskatchewan"/>
 	</owl:NamedIndividual>
 	
@@ -2316,10 +2314,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>TN</rdfs:label>
 		<skos:definition>US-specific code for the designation for Tennessee</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TN</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>TN</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Tennessee"/>
+		<cmns-dsg:hasTag>TN</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Tennessee"/>
 	</owl:NamedIndividual>
 	
@@ -2327,10 +2325,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>TX</rdfs:label>
 		<skos:definition>US-specific code for the designation for Texas</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TX</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>TX</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Texas"/>
+		<cmns-dsg:hasTag>TX</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Texas"/>
 	</owl:NamedIndividual>
 	
@@ -2421,10 +2419,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>UM</rdfs:label>
 		<skos:definition>US-specific code for the designation for the United States Minor Outlying Islands</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UM</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>UM</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;UnitedStatesMinorOutlyingIslands"/>
+		<cmns-dsg:hasTag>UM</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;UnitedStatesMinorOutlyingIslands"/>
 	</owl:NamedIndividual>
 	
@@ -2432,9 +2430,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&cmns-loc;GeographicRegionIdentifier"/>
 		<rdfs:label>US-AA</rdfs:label>
 		<skos:definition>subdivision code for the state designation for Armed Forces Americas, excluding Canada</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US-AA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AA</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
+		<cmns-dsg:hasTag>US-AA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
 	</owl:NamedIndividual>
 	
@@ -2442,9 +2440,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&cmns-loc;GeographicRegionIdentifier"/>
 		<rdfs:label>US-AE</rdfs:label>
 		<skos:definition>subdivision code for the state designation for Armed Forces Europe, the Middle East, and Canada</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US-AE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AE</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
+		<cmns-dsg:hasTag>US-AE</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
 	</owl:NamedIndividual>
 	
@@ -2452,9 +2450,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&cmns-loc;GeographicRegionIdentifier"/>
 		<rdfs:label>US-AP</rdfs:label>
 		<skos:definition>subdivision code for the state designation for Armed Forces Pacific</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US-AP</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>AP</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-dsg:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
+		<cmns-dsg:hasTag>US-AP</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
 	</owl:NamedIndividual>
 	
@@ -2462,10 +2460,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>UT</rdfs:label>
 		<skos:definition>US-specific code for the designation for Utah</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>UT</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Utah"/>
+		<cmns-dsg:hasTag>UT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Utah"/>
 	</owl:NamedIndividual>
 	
@@ -2495,10 +2493,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>VA</rdfs:label>
 		<skos:definition>US-specific code for the designation for Virginia</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>VA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>VA</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Virginia"/>
+		<cmns-dsg:hasTag>VA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Virginia"/>
 	</owl:NamedIndividual>
 	
@@ -2506,10 +2504,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>VI</rdfs:label>
 		<skos:definition>US-specific code for the designation for the U.S. Virgin Islands</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>VI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>VI</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;VirginIslands"/>
+		<cmns-dsg:hasTag>VI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;VirginIslands"/>
 	</owl:NamedIndividual>
 	
@@ -2517,10 +2515,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>VT</rdfs:label>
 		<skos:definition>US-specific code for the designation for Vermont</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>VT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>VT</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Vermont"/>
+		<cmns-dsg:hasTag>VT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Vermont"/>
 	</owl:NamedIndividual>
 	
@@ -2611,10 +2609,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>WA</rdfs:label>
 		<skos:definition>US-specific code for the designation for Washington</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WA</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>WA</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Washington"/>
+		<cmns-dsg:hasTag>WA</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Washington"/>
 	</owl:NamedIndividual>
 	
@@ -2622,10 +2620,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>WI</rdfs:label>
 		<skos:definition>US-specific code for the designation for Wisconsin</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>WI</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Wisconsin"/>
+		<cmns-dsg:hasTag>WI</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Wisconsin"/>
 	</owl:NamedIndividual>
 	
@@ -2633,10 +2631,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>WV</rdfs:label>
 		<skos:definition>US-specific code for the designation for West Virginia</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WV</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>WV</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;WestVirginia"/>
+		<cmns-dsg:hasTag>WV</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;WestVirginia"/>
 	</owl:NamedIndividual>
 	
@@ -2644,10 +2642,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>WY</rdfs:label>
 		<skos:definition>US-specific code for the designation for Wyoming</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WY</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>WY</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-us;Wyoming"/>
+		<cmns-dsg:hasTag>WY</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-us;Wyoming"/>
 	</owl:NamedIndividual>
 	
@@ -2706,11 +2704,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
 		<rdfs:label>YT</rdfs:label>
 		<skos:definition>Canadian and US-specific code for the designation for Yukon</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>YT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:preferredDesignation>YT</fibo-fnd-utl-av:preferredDesignation>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
 		<cmns-cxtdsg:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
 		<cmns-dsg:denotes rdf:resource="&lcc-3166-2-ca;Yukon"/>
+		<cmns-dsg:hasTag>YT</cmns-dsg:hasTag>
 		<cmns-id:identifies rdf:resource="&lcc-3166-2-ca;Yukon"/>
 	</owl:NamedIndividual>
 	

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -38,7 +38,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 		<rdfs:label>Relations Ontology</rdfs:label>
 		<dct:abstract>This ontology defines a set of general purpose relations for use in other FIBO ontology elements. These include a number of properties required for reuse across the foundations and business entities models.</dct:abstract>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2013-2025 Object Management Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -57,7 +57,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20251201/Relations/Relations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/Relations/Relations/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20170201/Relations/Relations.rdf version of this ontology was modified per the FIBO 2.0 RFC to include additional properties and the linkage to LCC.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Relations/Relations.owl version of the ontology submitted with the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
 	(1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
@@ -76,7 +76,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Relations/Relations.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Relations/Relations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Relations/Relations.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and remove the unused hasDispositionDate property, whose semantics were unclear at best.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions, to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name, to loosen domain restrictions on some properties which were too narrowly specified, and to add two new properties, describes and isDescribedBy, which are more appropriate for certain cases where we were using characterizes and isCharacterizedBy.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions, to deprecate cmns-dsg;hasTag in favor of the simpler LCC property of the same name, to loosen domain restrictions on some properties which were too narrowly specified, and to add two new properties, describes and isDescribedBy, which are more appropriate for certain cases where we were using characterizes and isCharacterizedBy.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Relations/Relations.rdf version of this ontology was modified to move the property &apos;exchanges&apos; to FND given that it could be applied more generally than with respect to swaps only.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20201201/Relations/Relations.rdf version of this ontology was modified to clean up references to external dictionaries that don&apos;t meet FIBO policies, eliminate ambiguity where possible, eliminate the superproperties of produces and is produced by, whose semantics are different from their parent properties, and improve ISO 704 compliance of definitions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210201/Relations/Relations.rdf version of this ontology was modified to add Reference as a superclass of Name and use the hasTextValue property as the superproperty of certain data properties.</skos:changeNote>
@@ -89,9 +89,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/Relations/Relations.rdf version of the ontology was modified to eliminate elements that have been deprecated for several quarters (FND-386).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20241101/Relations/Relations.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Relations/Relations.rdf version of the ontology was modified to eliminate elements that have been deprecated for more than 3 quarters (FND-399).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20251201/Relations/Relations.rdf version of the ontology was modified to deprecate duplicate properties, including some that are now available in Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fnd-rel-rel;Referent">
@@ -156,8 +157,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;hasDesignation">
-		<rdfs:label>has designation</rdfs:label>
-		<skos:definition>relates an individual or organization to a position, role, or other designation</skos:definition>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-rlcmp;hasRole"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasFormalName">
@@ -173,11 +174,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasTag">
-		<rdfs:subPropertyOf rdf:resource="&cmns-txt;hasTextValue"/>
-		<rdfs:label>has tag</rdfs:label>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition>combination of alphanumeric characters corresponding to a label for something</skos:definition>
-		<skos:note>Text-valued tags may be useful for automated transformation or encoding systems, such as those used to produce IETF compliant language tags in XML. Such tags are required to be string-valued in FIBO, but not language-tagged strings.</skos:note>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&cmns-dsg;hasTag"/>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;holds">

--- a/LOAN/LoansSpecific/CardAccounts.rdf
+++ b/LOAN/LoansSpecific/CardAccounts.rdf
@@ -68,10 +68,10 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansSpecific/CardAccounts/">
 		<rdfs:label>Card Accounts Ontology</rdfs:label>
 		<dct:abstract>This ontology defines revolving credit account-related concepts that are specific to credit and debit cards. Note that it does not differentiate between consumer and commercial/corporate cards and is capable of representing either.</dct:abstract>
-		<dct:license>Copyright (c) 2020-2025 EDM Council, Inc.
-		Copyright (c) 2020-2025 Object Management Group, Inc.
+		<dct:license>2020-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2020-2025 Object Management Group, Inc.
 		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
@@ -108,9 +108,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20231201/LoansSpecific/CardAccounts.rdf version of the ontology was modified to replace additional concepts from several FIBO FND ontologies with their counterparts added to the Commons Ontology Library (Commons) v1.1.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20240101/LoansSpecific/CardAccounts.rdf version of the ontology was modified to improve the class hierarchy for credit card agreement.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20241001/LoansSpecific/CardAccounts.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/LOAN/20250301/LoansSpecific/CardAccounts.rdf version of the ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2020-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2020-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-spc-crd;AmericanExpressNetwork">
@@ -260,7 +261,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -450,14 +451,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
-				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-spc-crd;CardProduct"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>credit card network</rdfs:label>

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -3,8 +3,8 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-eq-10962 "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
@@ -21,8 +21,8 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-eq-10962="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
@@ -39,8 +39,16 @@
 		<rdfs:label>Equities CFI Classification Individuals Ontology</rdfs:label>
 		<dct:abstract>This ontology covers the ISO 10962, Fourth edition, 2019-10 classification codes for instruments that represent an ownership interest in an entity or pool of assets. It is intended to cover sections most of the codes included in section 6.2 of the standard, with the exception of structured instruments, section 6.2.8, which will be covered under derivatives.</dct:abstract>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<dct:license>2020-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2020-2025 Object Management Group, Inc.
+		
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
@@ -49,7 +57,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20230601/Equities/EquityCFIClassificationIndividuals/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20260701/Equities/EquityCFIClassificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to streamline the representation of voting rights and payment form, eliminate embedded restrictions, and build out additional classes representing the various feature-based descriptions supported by the CFI standard.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20201201/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to complete the set of possible common share representations corresponding to the CFI standard, complete the set of corresponding codes for common shares (non-convertible), and add the set of possible combinations for preferred shares (non-convertible).</skos:changeNote>
@@ -58,9 +67,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20220801/Equities/EquityCFIClassificationIndividuals.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was modified to add a parent class of extendable preferred share where appropriate.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230601/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was modified to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412)</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;CommonEnhancedVotingRestrictedFullyPaidRegisteredShare">
@@ -451,192 +461,192 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESETFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, restricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESETFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESETFR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESETOR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESETOR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, restricted transfer, nil paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESETOR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESETOR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESETPR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESETPR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, restricted transfer, partly paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESETPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESETPR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESEUFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESEUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, unrestricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESEUFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESEUFR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESEUOR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESEUOR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, unrestricted transfer, nil paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESEUOR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESEUOR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESEUPR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESEUPR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, unrestricted transfer, partially paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESEUPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESEUPR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNTFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESNTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, restricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESNTFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESNTFR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNTOR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESNTOR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, restricted transfer, nil paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESNTOR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESNTOR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNTPR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESNTPR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, restricted transfer, partially paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESNTPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESNTPR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNUFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESNUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, unrestricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESNUFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESNUFR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNUOR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESNUOR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, unrestricted transfer, nil paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESNUOR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESNUOR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNUPR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESNUPR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, unrestricted transfer, partially paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESNUPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESNUPR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRTFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESRTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, restricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESRTFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESRTFR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRTOR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESRTOR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, restricted transfer, nil paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESRTOR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESRTOR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRTPR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESRTPR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, restricted transfer, partly paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESRTPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESRTPR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRUFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESRUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, unrestricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESRUFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESRUFR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRUOR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESRUOR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, unrestricted transfer, nil paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESRUOR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESRUOR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRUPR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESRUPR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, unrestricted transfer, partly paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESRUPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESRUPR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVTFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESVTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, restricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESVTFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESVTFR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVTOR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESVTOR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, restricted transfer, nil paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESVTOR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESVTOR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVTPR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESVTPR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, restricted transfer, partly paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESVTPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESVTPR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVUFR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESVUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, unrestricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESVUFR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESVUFR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVUOR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESVUOR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, unrestricted transfer, nil paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESVUOR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESVUOR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVUPR">
 		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdfs:label>ESVUPR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, unrestricted transfer, partly paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESVUPR</fibo-fnd-rel-rel:hasTag>
 		<cmns-col:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
+		<cmns-dsg:hasTag>ESVUPR</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-10962;PreferredEnhancedVotingExchangeableAdjustableIncomeRegisteredShare">

--- a/SEC/Securities/SecuritiesClassification.rdf
+++ b/SEC/Securities/SecuritiesClassification.rdf
@@ -7,7 +7,6 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-sec-cls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -24,7 +23,6 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-sec-cls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -36,16 +34,24 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/">
 		<rdfs:label>Securities Classification Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for classifying financial instruments, particularly securities, including, but not limited to classification schemes developed by government, regulatory agencies, and industry to classify the issuers of such securities as well as the securities themselves.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:license>Copyright (c) 2016-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2016-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+		
+		See https://opensource.org/licenses/MIT.</dct:license>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20231201/Securities/SecuritiesClassification/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20260701/Securities/SecuritiesClassification/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesClassification.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesClassification.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesClassification.rdf version of this ontology was modified to add an class representing the ISO 10962 CFI standard and an individual for the 2019 version of that standard.</skos:changeNote>
@@ -54,9 +60,10 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20210401/Securities/SecuritiesClassification.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230201/Securities/SecuritiesClassification.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC) and to eliminate redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20230301/Securities/SecuritiesClassification.rdf version of this ontology was augmented to include additional securities classification schemes that are widely used (SEC-119).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20231201/Securities/SecuritiesClassification.rdf version of this ontology was modified to replace duplicate properties (FND-412).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2016-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2018-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2016-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
@@ -118,7 +125,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/etc/testing/data/fnd/Organizations/TestFormalOrganizations.rdf
+++ b/etc/testing/data/fnd/Organizations/TestFormalOrganizations.rdf
@@ -5,7 +5,6 @@
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-tst-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/TestFormalOrganizations/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -20,7 +19,6 @@
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-tst-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/TestFormalOrganizations/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -34,26 +32,26 @@
 		<dct:abstract>This ontology tests the high level concept of formal organization used in other FIBO ontology elements.</dct:abstract>
 		<dct:contributor>Adaptive Analytics, Inc.</dct:contributor>
 		<dct:contributor>Thematix Partners LLC</dct:contributor>
-		<dct:license>Copyright (c) 2013-2025 EDM Council, Inc.
-		Copyright (c) 2013-2025 Object Management Group, Inc.
-		
-		Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+		<dct:license>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.
+Copyright (c) 2013-2025 Object Management Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		
 		See https://opensource.org/licenses/MIT.</dct:license>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Organizations/TestFormalOrganizations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20260701/Organizations/TestFormalOrganizations/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20210401/Organizations/TestFormalOrganizations.rdf version of the ontology was modified to use the Commons Ontology Library (Commons) Annotation Vocabulary rather than the OMG&apos;s Specification Metadata vocabulary.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230201/Organizations/TestFormalOrganizations.rdf version of this ontology was modified to use the Commons Ontology Library (Commons) rather than the OMG&apos;s Languages, Countries and Codes (LCC), eliminating redundancies in FIBO as appropriate.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20231201/Organizations/TestFormalOrganizations.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/Organizations/TestFormalOrganizations.rdf version of the ontology was modified to replace additional properties that are now available in the OMG Commons Ontology Library (Commons) v1.3 (FND-412).</skos:changeNote>
 		<skos:changeNote>This version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
    (2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -65,8 +63,8 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 Revisions to FIBO Foundations are managed per the process outlined in the Policies and Procedures for OMG standards, with the intent to maintain backwards compatibility in the ontologies to the degree possible.
   
 The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been checked for syntactic errors and logical consistency with Protege 4 (http://protege.stanford.edu/), HermiT 1.3.7 (http://www.hermit-reasoner.com/) and Pellet 2.2 (http://clarkparsia.com/pellet/).</skos:historyNote>
-		<cmns-av:copyright>Copyright (c) 2013-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;AtlasBank">
@@ -77,7 +75,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;AtlasBankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000008</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000008</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;BigBank">
@@ -88,7 +86,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;BigBankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000001</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000001</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;CaliforniaBank">
@@ -99,7 +97,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;CaliforniaBankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000002</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000002</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;FrankfurtBank">
@@ -110,7 +108,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;FrankfurtBankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000010</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000010</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;GlobalBank">
@@ -121,7 +119,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;GlobalbankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000012</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000012</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;GoodBank">
@@ -132,7 +130,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;GoodBankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000003</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000003</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;LondonBank">
@@ -143,7 +141,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;LondonBankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000014</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000014</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;NewConceptInc">
@@ -154,7 +152,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;NewConceptIncIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000007</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000007</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;NewYorkBank">
@@ -165,7 +163,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;NewYorkBankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000006</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000006</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;ParisBank">
@@ -176,7 +174,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;ParisBankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000011</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000011</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;SecuritiesInc">
@@ -187,7 +185,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;SecuritiesIncIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000004</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000004</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;TraderInc">
@@ -198,7 +196,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;TraderIncIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000005</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000005</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;TrustedBank">
@@ -209,7 +207,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;TrustedBankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000013</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000013</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;WallStreetBank">
@@ -220,7 +218,7 @@ The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been chec
 	
 	<owl:NamedIndividual rdf:about="&fibo-tst-fnd-org-fm;WallStreetBankIdentifier">
 		<rdf:type rdf:resource="&cmns-id;Identifier"/>
-		<fibo-fnd-rel-rel:hasTag>100000009</fibo-fnd-rel-rel:hasTag>
+		<cmns-dsg:hasTag>100000009</cmns-dsg:hasTag>
 	</owl:NamedIndividual>
 
 </rdf:RDF>


### PR DESCRIPTION
## Description

Deprecated properties, including hasTag, from FND and replaced usage with the Commons equivalents

Fixes: #2231 / FND-412


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


