### PR TITLE
FBC-336 - Add support for ISO 24165 Digital Token Identifier (DTI) (WIP)

### DIFF
--- a/FBC/FinancialInstruments/FinancialInstruments.rdf
+++ b/FBC/FinancialInstruments/FinancialInstruments.rdf
@@ -60,7 +60,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 		<rdfs:label>Financial Instruments Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for financial instruments in general, providing the high-level hooks for build-out in more detail in the relevant domain areas. These include, but are not limited to, equities, options, debt instruments, and so forth, some of which may be negotiable.</dct:abstract>
-		<dct:license>Copyright (c) 2015-2025 EDM Council, Inc.
+		<dct:license>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.
 Copyright (c) 2015-2025 Object Management Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &apos;Software&apos;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -91,7 +91,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20251201/FinancialInstruments/FinancialInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260801/FinancialInstruments/FinancialInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified for the FIBO 2.0 RFC, including minor bug fixes.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FinancialInstruments/FinancialInstruments/ version of this ontology was modified as a part of organizational hierarchy simplification, to add maturity-related properties, and to add exempt security.</skos:changeNote>
@@ -121,9 +121,10 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/FinancialInstruments/FinancialInstruments.rdf version of the ontology was modified to add calculation agent, which may appear at a higher level than derivatives (DER-55).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250501/FinancialInstruments/FinancialInstruments.rdf version of the ontology was modified to replace hasConstituent with hasMember for better semantic consistency (FND-396) and to reclassify entitlement under financial instrument, since not all entitlements are securities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250901/FinancialInstruments/FinancialInstruments.rdf version of the ontology was modified to eliminate long-time deprecated elements (FND-399).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251201/FinancialInstruments/FinancialInstruments.rdf version of the ontology was modified to clarify the definition of issuer (FND-336).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-		<cmns-av:copyright>Copyright (c) 2015-2025 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;CreditFacility">
@@ -364,7 +365,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>issuer</rdfs:label>
-		<skos:definition>role of a party that issues (or proposes to issue in a formal filing) one or more financial instruments</skos:definition>
+		<skos:definition>role of a party that makes (or proposes to make) one or more financial instruments available in some well-defined, typically formal way</skos:definition>
 		<cmns-av:adaptedFrom>Securities Exchange Act of 1934, as amended 12 August 2012</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>An issuer can be any legal person, including a legally competent natural person, company, government, or political subdivision, agency, or instrumentality of a government, depending on the nature of the instrument. A person might provide a loan directly to another party, but most instruments are issued by legal entities.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>With respect to certificates of deposit for securities, voting-trust certificates, or collateral- trust certificates, or with respect to certificates of interest or shares in an unincorporated investment trust not having a board of directors or of the fixed, restricted management, or unit type, the term issuer means the person or persons performing the acts and assuming the duties of depositor or manager pursuant to the provisions of the trust or other agreement or instrument under which such securities are issued; and except that with respect to equipment-trust certificates or like securities, the term issuer means the person by whom the equipment or property is, or is to be, used.</cmns-av:explanatoryNote>

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -818,7 +818,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;Ledger">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Record"/>
+		<rdfs:subClassOf rdf:resource="&cmns-doc;Record"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;comprises"/>

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -31,6 +31,7 @@
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
+	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
@@ -73,6 +74,7 @@
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
+	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
@@ -108,6 +110,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -668,9 +671,24 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;DistributedLedger">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Ledger"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-gao-obj;usesMethod"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;DistributedLedgerTechnology"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>distributed ledger</rdfs:label>
-		<dct:source>ISO 24165-1:2025, Digital token identifier (DTI) - Registration, assignment and structure, Part 1: Method for registration and assignment, Second edition, 2025-05.</dct:source>
-		<skos:definition>ledger that is shared across a set of distributed ledger technology nodes and synchronized between the distributed ledger technology nodes using a consensus mechanism</skos:definition>
+		<skos:definition>ledger that is shared across a set of nodes and synchronized between the nodes using a consensus mechanism</skos:definition>
+		<skos:note>A distributed ledger is designed to be immutable, tamper-resistant, tamper-evident and append-only, containing final and definitive ledger records of confirmed and validated transactions. The nodes in the network use distributed ledger technology for communications and synchronization purposes.</skos:note>
+		<cmns-av:adaptedFrom>ISO 24165-1:2025, Digital token identifier (DTI) - Registration, assignment and structure, Part 1: Method for registration and assignment, Second edition, 2025-05.</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;DistributedLedgerTechnology">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Method"/>
+		<rdfs:label>distributed ledger technology</rdfs:label>
+		<skos:definition>method that enables the operation and use of distributed ledgers</skos:definition>
+		<cmns-av:abbreviation>DLT</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>ISO 24165-1:2025, Digital token identifier (DTI) - Registration, assignment and structure, Part 1: Method for registration and assignment, Second edition, 2025-05.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;Fee">

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -129,7 +129,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260701/ProductsAndServices/ClientsAndAccounts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20260801/ProductsAndServices/ClientsAndAccounts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised per the FIBO 2.0 RFC with respect to the definitions for accounts and account identifiers, such as BBAN and IBAN identifiers, including but not limited to bank accounts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to support the addition of maturity-related properties to financial instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181101/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
@@ -154,6 +154,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20250301/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to use new constructs from the Commons 1.3 Business Authorizations ontology (FND-401).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251201/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to add the concept of a chart of accounts (FND-398).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20251201/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to reflect migration of concepts from accounting equity to ownership in FND (FND-409), to reflect definition refinement in financial products and services (SEC-219), and to replace references to the now deprecated hasTag property in Relations with its equivalent in OMG Commons (FND-412).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20260701/ProductsAndServices/ClientsAndAccounts.rdf version of the ontology was modified to add the concept of a distributed ledger (FBC-336).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2015-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -665,6 +666,13 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<cmns-av:explanatoryNote>The account holder has the right to withdraw deposited funds, as set forth in the terms and conditions governing the account agreement. Deposit accounts may be insured up to a certain amount, depending on the jurisdiction.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;DistributedLedger">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Ledger"/>
+		<rdfs:label>distributed ledger</rdfs:label>
+		<dct:source>ISO 24165-1:2025, Digital token identifier (DTI) - Registration, assignment and structure, Part 1: Method for registration and assignment, Second edition, 2025-05.</dct:source>
+		<skos:definition>ledger that is shared across a set of distributed ledger technology nodes and synchronized between the distributed ledger technology nodes using a consensus mechanism</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;Fee">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<rdfs:label>fee</rdfs:label>
@@ -672,15 +680,11 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;GeneralLedger">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Ledger"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;FinancialRecord"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;LedgerAccount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>general ledger</rdfs:label>
 		<skos:definition>organized collection of ledger accounts used to record and summarize changes in position as transactions are posted during an accounting period</skos:definition>
+		<cmns-av:explanatoryNote>A general ledger is used to aggregate all financial records of an organization for analysis and reporting purposes. It is specific to the accounting domain, whereas the concept of a &apos;ledger&apos; may apply more broadly.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;IndividualTransaction">
@@ -811,6 +815,19 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>investment or deposit account</rdfs:label>
 		<skos:definition>account associated with a product or service that requires the account holder to provide funds for management by the account provider</skos:definition>
 		<cmns-av:explanatoryNote>The account holder may or may not be entitled to consideration in exchange for providing such funds, for example, interest, depending on the type of account and the terms and conditions associated with it. Also, there may be fees associated with management services provided by the account provider. Note too that this may be an internal account held on behalf of an institution or a customer account.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;Ledger">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Record"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;LedgerAccount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>ledger</rdfs:label>
+		<skos:definition>organized record of business activities and transactions</skos:definition>
+		<skos:example>inventory ledger, blockchain ledger, general ledger</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;LedgerAccount">

--- a/FND/OwnershipAndControl/Ownership.rdf
+++ b/FND/OwnershipAndControl/Ownership.rdf
@@ -82,7 +82,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20230301/OwnershipAndControl/Ownership.rdf version of this ontology was modified to replace content that is now available in the OMG Commons Ontology Library (Commons) v1.1 (FND-380).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20240101/OwnershipAndControl/Ownership.rdf version of the ontology was modified to replace additional content that is now available in the OMG Commons Ontology Library (Commons) v1.2 (FND-389).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250301/OwnershipAndControl/Ownership.rdf version of the ontology was modified to add an explanatory note to ownership (SEC-202).</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250701/OwnershipAndControl/Ownership.rdf version of the ontology was modified to incorporate concepts that were originally in the accounting equity ontology into this ontology to improve usability (FND-409) and to add the concept of a portfolio and holding in order to further simplify imports and improve usability and maintenance (SEC-219).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20250701/OwnershipAndControl/Ownership.rdf version of the ontology was modified to incorporate concepts that were originally in the accounting equity ontology into this ontology to improve usability (FND-409) and to add the concept of a portfolio and holding in order to further simplify imports and improve usability and maintenance (SEC-219), and to add the definition ofdigital asset (FBC-336).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 		<cmns-av:copyright>Copyright (c) 2013-2025 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2026 EDM Association dba EDM Council, Inc.</cmns-av:copyright>
@@ -119,7 +119,9 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>asset</rdfs:label>
 		<skos:definition>something of monetary value that is owned or provides benefit to some party</skos:definition>
 		<cmns-av:adaptedFrom>Financial Accounting Standards Board (FASB) Statement of Financial Accounting Concepts No. 6, Elements of Financial Statements, paragraph 25.</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 24165-2:2025, Digital token identifier (DTI), Registration, assignment and structure, Second edition, 2025-6, which references the definition from ISO 22739 in defining the notion of a digital asset for the purposes of blockchain technology.</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>An asset is something that provides probable future economic benefit obtained or controlled by some party as a result of past transactions or events. An asset has three essential characteristics: (a) it embodies a probable future benefit that involves a capacity, singly or in combination with other assets, to contribute directly or indirectly to future net cash inflows, (b) a party can obtain the benefit and control others&apos; access to it, and (c) the transaction or other event giving rise to the party&apos;s right to or control of the benefit has already occurred.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>ISO 22739:2024 defines asset as &apos;anything that has value to a stakeholder&apos;, without being specific as to the form &apos;value&apos; takes.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>economic resource</cmns-av:synonym>
 	</owl:Class>
 	
@@ -127,6 +129,23 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;PaidInCapital"/>
 		<rdfs:label>capital surplus</rdfs:label>
 		<skos:definition>capital contributed in excess of the par value (stated value) of the ownership interest issued</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-oac-own;DigitalAsset">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
+		<rdfs:label>digital asset</rdfs:label>
+		<skos:definition>asset that exists only in digital form or that is the digital representation of another asset</skos:definition>
+		<cmns-av:adaptedFrom>ISO 24165-2:2025, Digital token identifier (DTI), Registration, assignment and structure, Second edition, 2025-6, which references the definition from ISO 22739 in defining the notion of a digital asset for the purposes of blockchain technology.</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-oac-own;DigitalToken">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;DigitalAsset"/>
+		<rdfs:label>digital token</rdfs:label>
+		<dct:source>ISO 24165-2:2025, Digital token identifier (DTI), Registration, assignment and structure, Second edition, 2025-6.</dct:source>
+		<skos:definition>fungible digital asset which uses distributed ledger technology for its issuance, storage, exchange, record of ownership or transaction validation and is not a currency</skos:definition>
+		<skos:note>Digital assets described by non-standard terms, including but not limited to cryptocurrency, virtual currency, digital currency, utility token, security token, cryptoasset, payment token, stablecoin or coloured coin, are considered digital tokens for the purposes ISO 24165.</skos:note>
+		<cmns-av:explanatoryNote>Because digital currencies are considered digital tokens according to ISO 24165, we have not included a disjointness relationship between digital token and currency, though the definition implies that such a disjointness should be present.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>ISO 24165 defines the term &apos;fungible&apos; as something &apos;capable of mutual substitution between the individual units of digital assets.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-oac-own;EarningsBeforeInterestTaxesDepreciationAmortization">
@@ -193,6 +212,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<skos:definition>identifiable, non-monetary asset that lacks physical substance</skos:definition>
 		<skos:example>Intangible assets may include intellectual property, patents, copyrights, trademarks, rights-of-way (easements), brands, organizational abilities (know-how), and data.</skos:example>
 		<cmns-av:explanatoryNote>Intangible assets include assets that may involve a legal claim to some future benefit, typically a claim to future cash. Intangible assets have become an increasingly larger component of the valuation for all companies, from newer social media companies to even the most established and iconic manufacturers.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-oac-own;NonFungibleToken">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;DigitalToken"/>
+		<rdfs:label>non-fungible token</rdfs:label>
+		<dct:source>ISO 24165-2:2025, Digital token identifier (DTI), Registration, assignment and structure, Second edition, 2025-6.</dct:source>
+		<skos:definition>unique digital token that represents proof of ownership of one or more tangible and/or intangible assets with unique metadata and/or identification such that no two are identical or fungible</skos:definition>
+		<cmns-av:abbreviation>NFT</cmns-av:abbreviation>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-oac-own;Owner">

--- a/FND/OwnershipAndControl/Ownership.rdf
+++ b/FND/OwnershipAndControl/Ownership.rdf
@@ -142,7 +142,7 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;DigitalAsset"/>
 		<rdfs:label>digital token</rdfs:label>
 		<dct:source>ISO 24165-2:2025, Digital token identifier (DTI), Registration, assignment and structure, Second edition, 2025-6.</dct:source>
-		<skos:definition>fungible digital asset which uses distributed ledger technology for its issuance, storage, exchange, record of ownership or transaction validation and is not a currency</skos:definition>
+		<skos:definition>digital asset which uses distributed ledger technology for its issuance, storage, exchange, record of ownership or transaction validation and is not a currency</skos:definition>
 		<skos:note>Digital assets described by non-standard terms, including but not limited to cryptocurrency, virtual currency, digital currency, utility token, security token, cryptoasset, payment token, stablecoin or coloured coin, are considered digital tokens for the purposes ISO 24165.</skos:note>
 		<cmns-av:explanatoryNote>Because digital currencies are considered digital tokens according to ISO 24165, we have not included a disjointness relationship between digital token and currency, though the definition implies that such a disjointness should be present.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>ISO 24165 defines the term &apos;fungible&apos; as something &apos;capable of mutual substitution between the individual units of digital assets.</cmns-av:explanatoryNote>
@@ -175,6 +175,14 @@ THE SOFTWARE IS PROVIDED &apos;AS IS&apos;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 		<rdfs:label>financial asset</rdfs:label>
 		<skos:definition>non-physical, tangible asset whose value is derived from a contractual claim, such as bank deposits, bonds, stocks, rights, certificates, and bank balances</skos:definition>
 		<cmns-av:explanatoryNote>Financial assets are typically more liquid than other tangible assets, such as commodities or real estate. Financial assets may not cover all assets that might be included on a balance sheet, and do not include tangible, physical assets or intangible assets such as intellectual property.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-oac-own;FungibleToken">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;DigitalToken"/>
+		<rdfs:label>fungible token</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-fnd-oac-own;NonFungibleToken"/>
+		<skos:definition>digital token capable of mutual substitution between the individual units of digital assets</skos:definition>
+		<cmns-av:adaptedFrom>ISO 24165-2:2025, Digital token identifier (DTI), Registration, assignment and structure, Second edition, 2025-6.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-oac-own;Holding">


### PR DESCRIPTION
## Description

1. Added metadata to the definition of asset, added definitions for digital asset, digital token, and NFT from ISO 24165
2. Loosened the definition of the property 'issues' to accommodate private issuance and concepts related to digital assets
3. Integrated the definition of ledger, distributed ledger

Fixes: #2235 / FBC-336


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](https://github.com/edmcouncil/fibo/blob/master/CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


